### PR TITLE
Spark Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,23 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jetty.version>9.4.33.v20201020</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <!-- Test -->
+        <junit.version>4.13.2</junit.version>
+        <httpclient.version>4.5.13</httpclient.version>
+        <freemarker.version>2.3.31</freemarker.version>
+        <gson.version>2.9.0</gson.version>
+        <!-- Plugin -->
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
+        <maven-bundle-plugin.version>5.1.4</maven-bundle-plugin.version>
+        <dependency-check-maven.version>7.0.1</dependency-check-maven.version>
     </properties>
 
     <dependencies>
@@ -41,13 +54,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -79,7 +92,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -103,19 +116,19 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
+            <version>${httpclient.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
+            <version>${freemarker.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>${gson.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -149,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -160,7 +173,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -180,7 +193,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
@@ -189,7 +202,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <failOnError>false</failOnError>
                 </configuration>
@@ -197,8 +210,23 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>${maven-bundle-plugin.version}</version>
                 <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${dependency-check-maven.version}</version>
+                <configuration>
+                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/spark/Base64Test.java
+++ b/src/test/java/spark/Base64Test.java
@@ -3,8 +3,6 @@ package spark;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class Base64Test {
 
     //CS304 manually Issue link:https://github.com/perwendel/spark/issues/1061

--- a/src/test/java/spark/MultipleServicesTest.java
+++ b/src/test/java/spark/MultipleServicesTest.java
@@ -26,7 +26,6 @@ import spark.routematch.RouteMatch;
 import spark.util.SparkTestUtil;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
 import static spark.Service.ignite;
 
 /**

--- a/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
+++ b/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
@@ -6,7 +6,6 @@ import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.AfterClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;


### PR DESCRIPTION
Added properties for all dependencies and plugins (for consistency).

Updated dependencies:
Jetty from 9.4.33.v20201020 to 9.4.45.v20220203
SLF4J from 1.7.25 to 1.7.36
HTTP Client 4.5.6 from to 4.5.13
JUnit from 4.12 to 4.13.2
Freemarker 2.3.28 from to 2.3.31
Gson from 2.8.5 to 2.9.0

Updated all plugins to latest version.

Added OWASP plugin to validate vulnerabilities.