### PR TITLE
Test Framework Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,14 +29,16 @@
     </developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cvss.core>4</cvss.core>
         <java.version>1.8</java.version>
         <jetty.version>9.4.45.v20220203</jetty.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <powermock.version>1.7.4</powermock.version>
-        <mockito.version>1.10.19</mockito.version>
         <slf4j.version>1.7.36</slf4j.version>
         <!-- Test -->
-        <junit.version>4.13.2</junit.version>
+        <junit.version>5.8.2</junit.version>
+        <mockito.version>4.4.0</mockito.version>
+        <powermock.version>2.0.9</powermock.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <httpclient.version>4.5.13</httpclient.version>
         <freemarker.version>2.3.31</freemarker.version>
         <gson.version>2.9.0</gson.version>
@@ -89,30 +91,36 @@
         </dependency>
 
         <!-- JUNIT DEPENDENCY FOR TESTING -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-core</artifactId>
+			<version>${powermock.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest</artifactId>
+		    <version>${hamcrest.version}</version>
+		    <scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -218,7 +226,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>${dependency-check-maven.version}</version>
                 <configuration>
-                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                    <failBuildOnCVSS>${cvss.core}</failBuildOnCVSS>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/test/java/spark/Base64Test.java
+++ b/src/test/java/spark/Base64Test.java
@@ -1,7 +1,8 @@
 package spark;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Base64Test {
 
@@ -11,7 +12,7 @@ public class Base64Test {
     public final void test_encode() {
         String in = "hello";
         String encode = Base64.encode(in);
-        Assert.assertFalse(in.equals(encode));
+        assertNotEquals(in, encode);
     }
 
     //CS304 manually Issue link:https://github.com/perwendel/spark/issues/1061
@@ -22,7 +23,7 @@ public class Base64Test {
         String encode = Base64.encode(in);
         String decode = Base64.decode(encode);
 
-        Assert.assertTrue(in.equals(decode));
+        assertEquals(in, decode);
     }
 
 }

--- a/src/test/java/spark/BodyAvailabilityTest.java
+++ b/src/test/java/spark/BodyAvailabilityTest.java
@@ -1,14 +1,15 @@
 package spark;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.after;
 import static spark.Spark.before;
 import static spark.Spark.post;
@@ -21,13 +22,13 @@ public class BodyAvailabilityTest {
     
     private static SparkTestUtil testUtil;
 
-    private final int HTTP_OK = 200;
+    private static final int HTTP_OK = 200;
     
     private static String beforeBody = null;
     private static String routeBody = null;
     private static String afterBody = null;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
 
@@ -36,7 +37,7 @@ public class BodyAvailabilityTest {
         afterBody = null;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         LOGGER.debug("setup()");
 
@@ -69,11 +70,11 @@ public class BodyAvailabilityTest {
     public void testPost() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("POST", "/hello", BODY_CONTENT);
         LOGGER.info(response.body);
-        Assert.assertEquals(HTTP_OK, response.status);
-        Assert.assertTrue(response.body.contains(BODY_CONTENT));
+        assertEquals(HTTP_OK, response.status);
+        assertTrue(response.body.contains(BODY_CONTENT));
 
-        Assert.assertEquals(BODY_CONTENT, beforeBody);
-        Assert.assertEquals(BODY_CONTENT, routeBody);
-        Assert.assertEquals(BODY_CONTENT, afterBody);
+        assertEquals(BODY_CONTENT, beforeBody);
+        assertEquals(BODY_CONTENT, routeBody);
+        assertEquals(BODY_CONTENT, afterBody);
     }
 }

--- a/src/test/java/spark/BooksIntegrationTest.java
+++ b/src/test/java/spark/BooksIntegrationTest.java
@@ -1,59 +1,52 @@
 package spark;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.after;
 import static spark.Spark.before;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import spark.examples.books.Books;
 import spark.utils.IOUtils;
 
 public class BooksIntegrationTest {
 
-    private static int PORT = 4567;
+    private static final int PORT = 4567;
 
-    private static String AUTHOR = "FOO";
-    private static String TITLE = "BAR";
-    private static String NEW_TITLE = "SPARK";
+    private static final String AUTHOR = "FOO";
+    private static final String TITLE = "BAR";
+    private static final String NEW_TITLE = "SPARK";
 
     private String bookId;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
     }
 
-    @After
+    @AfterEach
     public void clearBooks() {
         Books.books.clear();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
-        before((request, response) -> {
-            response.header("FOZ", "BAZ");
-        });
+        before((request, response) -> response.header("FOZ", "BAZ"));
 
         Books.main(null);
 
-        after((request, response) -> {
-            response.header("FOO", "BAR");
-        });
+        after((request, response) -> response.header("FOO", "BAR"));
 
         Spark.awaitInitialization();
     }
@@ -64,7 +57,7 @@ public class BooksIntegrationTest {
 
         assertNotNull(response);
         assertNotNull(response.body);
-        assertTrue(Integer.valueOf(response.body) > 0);
+        assertTrue(Integer.parseInt(response.body) > 0);
         assertEquals(201, response.status);
     }
 
@@ -72,12 +65,12 @@ public class BooksIntegrationTest {
     public void canListBooks() {
         bookId = createBookViaPOST().body.trim();
 
-        UrlResponse response = doMethod("GET", "/books", null);
+        UrlResponse response = doMethod("GET", "/books");
 
         assertNotNull(response);
         String body = response.body.trim();
         assertNotNull(body);
-        assertTrue(Integer.valueOf(body) > 0);
+        assertTrue(Integer.parseInt(body) > 0);
         assertEquals(200, response.status);
         assertTrue(response.body.contains(bookId));
     }
@@ -86,7 +79,7 @@ public class BooksIntegrationTest {
     public void canGetBook() {
         bookId = createBookViaPOST().body.trim();
 
-        UrlResponse response = doMethod("GET", "/books/" + bookId, null);
+        UrlResponse response = doMethod("GET", "/books/" + bookId);
 
         String result = response.body;
         assertNotNull(response);
@@ -117,7 +110,7 @@ public class BooksIntegrationTest {
         bookId = createBookViaPOST().body.trim();
         updateBook();
 
-        UrlResponse response = doMethod("GET", "/books/" + bookId, null);
+        UrlResponse response = doMethod("GET", "/books/" + bookId);
 
         String result = response.body;
         assertNotNull(response);
@@ -131,7 +124,7 @@ public class BooksIntegrationTest {
     public void canDeleteBook() {
         bookId = createBookViaPOST().body.trim();
 
-        UrlResponse response = doMethod("DELETE", "/books/" + bookId, null);
+        UrlResponse response = doMethod("DELETE", "/books/" + bookId);
 
         String result = response.body;
         assertNotNull(response);
@@ -141,31 +134,27 @@ public class BooksIntegrationTest {
         assertTrue(result.contains("deleted"));
     }
 
-    @Test(expected = FileNotFoundException.class)
-    public void wontFindBook() throws IOException {
-        getResponse("GET", "/books/" + bookId, null);
+    @Test
+    public void wontFindBook() {
+        assertThrows(FileNotFoundException.class, () -> getResponse("GET", "/books/" + bookId, null));
     }
 
-    private static UrlResponse doMethod(String requestMethod, String path, String body) {
+    private static UrlResponse doMethod(String requestMethod, String path) {
         UrlResponse response = new UrlResponse();
-
         try {
             getResponse(requestMethod, path, response);
         } catch (IOException e) {
             e.printStackTrace();
         }
-
         return response;
     }
 
-    private static void getResponse(String requestMethod, String path, UrlResponse response)
-            throws MalformedURLException, IOException, ProtocolException {
+    private static void getResponse(String requestMethod, String path, UrlResponse response) throws IOException {
         URL url = new URL("http://localhost:" + PORT + path);
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod(requestMethod);
         connection.connect();
-        String res = IOUtils.toString(connection.getInputStream());
-        response.body = res;
+        response.body = IOUtils.toString(connection.getInputStream());
         response.status = connection.getResponseCode();
         response.headers = connection.getHeaderFields();
     }
@@ -177,11 +166,11 @@ public class BooksIntegrationTest {
     }
 
     private UrlResponse createBookViaPOST() {
-        return doMethod("POST", "/books?author=" + AUTHOR + "&title=" + TITLE, null);
+        return doMethod("POST", "/books?author=" + AUTHOR + "&title=" + TITLE);
     }
 
     private UrlResponse updateBook() {
-        return doMethod("PUT", "/books/" + bookId + "?title=" + NEW_TITLE, null);
+        return doMethod("PUT", "/books/" + bookId + "?title=" + NEW_TITLE);
     }
 
     private boolean afterFilterIsSet(UrlResponse response) {

--- a/src/test/java/spark/CookiesIntegrationTest.java
+++ b/src/test/java/spark/CookiesIntegrationTest.java
@@ -1,16 +1,16 @@
 package spark;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spark.Spark.*;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * System tests for the Cookies support.
@@ -20,10 +20,10 @@ import org.junit.Test;
 public class CookiesIntegrationTest {
 
     private static final String DEFAULT_HOST_URL = "http://localhost:4567";
-    private HttpClient httpClient = HttpClientBuilder.create().build();
+    private final HttpClient httpClient = HttpClientBuilder.create().build();
 
-    @BeforeClass
-    public static void initRoutes() throws InterruptedException {
+    @BeforeAll
+    public static void initRoutes() {
         post("/assertNoCookies", (request, response) -> {
             if (!request.cookies().isEmpty()) {
                 halt(500);
@@ -80,7 +80,7 @@ public class CookiesIntegrationTest {
 
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopServer() {
         Spark.stop();
     }

--- a/src/test/java/spark/ExceptionMapperTest.java
+++ b/src/test/java/spark/ExceptionMapperTest.java
@@ -1,12 +1,11 @@
 package spark;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
-import static org.junit.Assert.assertEquals;
-
 public class ExceptionMapperTest {
-
 
     @Test
     public void testGetInstance_whenDefaultInstanceIsNull() {
@@ -16,7 +15,7 @@ public class ExceptionMapperTest {
 
         //then
         exceptionMapper = ExceptionMapper.getServletInstance();
-        assertEquals("Should be equals because ExceptionMapper is a singleton", Whitebox.getInternalState(ExceptionMapper.class, "servletInstance"), exceptionMapper);
+        assertEquals(Whitebox.getInternalState(ExceptionMapper.class, "servletInstance"), exceptionMapper, "Should be equals because ExceptionMapper is a singleton");
     }
 
     @Test
@@ -26,6 +25,6 @@ public class ExceptionMapperTest {
 
         //then
         ExceptionMapper exceptionMapper = ExceptionMapper.getServletInstance();
-        assertEquals("Should be equals because ExceptionMapper is a singleton", Whitebox.getInternalState(ExceptionMapper.class, "servletInstance"), exceptionMapper);
+        assertEquals(Whitebox.getInternalState(ExceptionMapper.class, "servletInstance"), exceptionMapper, "Should be equals because ExceptionMapper is a singleton");
     }
 }

--- a/src/test/java/spark/FilterImplTest.java
+++ b/src/test/java/spark/FilterImplTest.java
@@ -1,52 +1,45 @@
 package spark;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class FilterImplTest {
 
-    public String PATH_TEST;
-    public String ACCEPT_TYPE_TEST;
+    private static final String PATH_TEST = "/etc/test";
+    private static final String ACCEPT_TYPE_TEST  = "test/*";
 
-    public FilterImpl filter;
-
-    @Before
-    public void setup(){
-        PATH_TEST = "/etc/test";
-        ACCEPT_TYPE_TEST  = "test/*";
-    }
+    private FilterImpl filter;
 
     @Test
     public void testConstructor(){
         FilterImpl filter = new FilterImpl(PATH_TEST, ACCEPT_TYPE_TEST) {
             @Override
-            public void handle(Request request, Response response) throws Exception {
+            public void handle(Request request, Response response) {
             }
         };
-        assertEquals("Should return path specified", PATH_TEST, filter.getPath());
-        assertEquals("Should return accept type specified", ACCEPT_TYPE_TEST, filter.getAcceptType());
+        assertEquals(PATH_TEST, filter.getPath(), "Should return path specified");
+        assertEquals(ACCEPT_TYPE_TEST, filter.getAcceptType(), "Should return accept type specified");
     }
 
     @Test
-    public void testGets_thenReturnGetPathAndGetAcceptTypeSuccessfully() throws Exception {
+    public void testGets_thenReturnGetPathAndGetAcceptTypeSuccessfully() {
         filter = FilterImpl.create(PATH_TEST, ACCEPT_TYPE_TEST, null);
-        assertEquals("Should return path specified", PATH_TEST, filter.getPath());
-        assertEquals("Should return accept type specified", ACCEPT_TYPE_TEST, filter.getAcceptType());
+        assertEquals(PATH_TEST, filter.getPath(), "Should return path specified");
+        assertEquals(ACCEPT_TYPE_TEST, filter.getAcceptType(), "Should return accept type specified");
     }
 
     @Test
     public void testCreate_whenOutAssignAcceptTypeInTheParameters_thenReturnPathAndAcceptTypeSuccessfully(){
         filter = FilterImpl.create(PATH_TEST, null);
-        assertEquals("Should return path specified", PATH_TEST, filter.getPath());
-        assertEquals("Should return accept type specified", RouteImpl.DEFAULT_ACCEPT_TYPE, filter.getAcceptType());
+        assertEquals(PATH_TEST, filter.getPath(), "Should return path specified");
+        assertEquals(RouteImpl.DEFAULT_ACCEPT_TYPE, filter.getAcceptType(), "Should return accept type specified");
     }
 
     @Test
     public void testCreate_whenAcceptTypeNullValueInTheParameters_thenReturnPathAndAcceptTypeSuccessfully(){
         filter = FilterImpl.create(PATH_TEST, null, null);
-        assertEquals("Should return path specified", PATH_TEST, filter.getPath());
-        assertEquals("Should return accept type specified", RouteImpl.DEFAULT_ACCEPT_TYPE, filter.getAcceptType());
+        assertEquals(PATH_TEST, filter.getPath(), "Should return path specified");
+        assertEquals(RouteImpl.DEFAULT_ACCEPT_TYPE, filter.getAcceptType(), "Should return accept type specified");
     }
 }

--- a/src/test/java/spark/FilterTest.java
+++ b/src/test/java/spark/FilterTest.java
@@ -1,15 +1,13 @@
 package spark;
 
 import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Spark.awaitInitialization;
 import static spark.Spark.before;
 import static spark.Spark.stop;
@@ -17,12 +15,12 @@ import static spark.Spark.stop;
 public class FilterTest {
     static SparkTestUtil testUtil;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         stop();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -35,7 +33,7 @@ public class FilterTest {
         UrlResponse response = testUtil.doMethod("GET", "/justfilter", null);
 
         System.out.println("response.status = " + response.status);
-        Assert.assertEquals(404, response.status);
+        assertEquals(404, response.status);
     }
 
 }

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,10 +16,9 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +31,10 @@ import spark.examples.exception.SubclassOfBaseException;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.after;
 import static spark.Spark.afterAfter;
 import static spark.Spark.before;
@@ -53,7 +57,7 @@ public class GenericIntegrationTest {
     static SparkTestUtil testUtil;
     static File tmpExternalFile;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
         if (tmpExternalFile != null) {
@@ -61,7 +65,7 @@ public class GenericIntegrationTest {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -76,23 +80,17 @@ public class GenericIntegrationTest {
         externalStaticFileLocation(System.getProperty("java.io.tmpdir"));
         webSocket("/ws", WebSocketTestHandler.class);
 
-        before("/secretcontent/*", (q, a) -> {
-            halt(401, "Go Away!");
-        });
+        before("/secretcontent/*", (q, a) -> halt(401, "Go Away!"));
 
-        before("/protected/*", "application/xml", (q, a) -> {
-            halt(401, "Go Away!");
-        });
+        before("/protected/*", "application/xml", (q, a) -> halt(401, "Go Away!"));
 
-        before("/protected/*", "application/json", (q, a) -> {
-            halt(401, "{\"message\": \"Go Away!\"}");
-        });
+        before("/protected/*", "application/json", (q, a) -> halt(401, "{\"message\": \"Go Away!\"}"));
 
         get("/hi", "application/json", (q, a) -> "{\"message\": \"Hello World\"}");
         get("/hi", (q, a) -> "Hello World!");
         get("/binaryhi", (q, a) -> "Hello World!".getBytes());
         get("/bytebufferhi", (q, a) -> ByteBuffer.wrap("Hello World!".getBytes()));
-        get("/inputstreamhi", (q, a) -> new ByteArrayInputStream("Hello World!".getBytes("utf-8")));
+        get("/inputstreamhi", (q, a) -> new ByteArrayInputStream("Hello World!".getBytes(StandardCharsets.UTF_8)));
         get("/param/:param", (q, a) -> "echo: " + q.params(":param"));
 
         path("/firstPath", () -> {
@@ -100,9 +98,7 @@ public class GenericIntegrationTest {
             get("/test", (q, a) -> "Single path-prefix works");
             path("/secondPath", () -> {
                 get("/test", (q, a) -> "Nested path-prefix works");
-                path("/thirdPath", () -> {
-                    get("/test", (q, a) -> "Very nested path-prefix works");
-                });
+                path("/thirdPath", () -> get("/test", (q, a) -> "Very nested path-prefix works"));
             });
         });
 
@@ -152,7 +148,7 @@ public class GenericIntegrationTest {
         after("/hi", (q, a) -> {
 
             if (q.requestMethod().equalsIgnoreCase("get")) {
-                Assert.assertNotNull(a.body());
+                assertNotNull(a.body());
             }
 
             a.header("after", "foobar");
@@ -174,17 +170,11 @@ public class GenericIntegrationTest {
             throw new JWGmeligMeylingException();
         });
 
-        exception(JWGmeligMeylingException.class, (meylingException, q, a) -> {
-            a.body(meylingException.trustButVerify());
-        });
+        exception(JWGmeligMeylingException.class, (meylingException, q, a) -> a.body(meylingException.trustButVerify()));
 
-        exception(UnsupportedOperationException.class, (exception, q, a) -> {
-            a.body("Exception handled");
-        });
+        exception(UnsupportedOperationException.class, (exception, q, a) -> a.body("Exception handled"));
 
-        exception(BaseException.class, (exception, q, a) -> {
-            a.body("Exception handled");
-        });
+        exception(BaseException.class, (exception, q, a) -> a.body("Exception handled"));
 
         exception(NotFoundException.class, (exception, q, a) -> {
             a.status(404);
@@ -195,19 +185,13 @@ public class GenericIntegrationTest {
             throw new RuntimeException();
         });
 
-        afterAfter("/exception", (request, response) -> {
-            response.body("done executed for exception");
-        });
+        afterAfter("/exception", (request, response) -> response.body("done executed for exception"));
 
         post("/nice", (request, response) -> "nice response");
 
-        afterAfter("/nice", (request, response) -> {
-            response.header("post-process", "nice done response");
-        });
+        afterAfter("/nice", (request, response) -> response.header("post-process", "nice done response"));
 
-        afterAfter((request, response) -> {
-            response.header("post-process-all", "nice done response after all");
-        });
+        afterAfter((request, response) -> response.header("post-process-all", "nice done response after all"));
 
         Spark.awaitInitialization();
     }
@@ -215,37 +199,37 @@ public class GenericIntegrationTest {
     @Test
     public void filters_should_be_accept_type_aware() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/protected/resource", null, "application/json");
-        Assert.assertTrue(response.status == 401);
-        Assert.assertEquals("{\"message\": \"Go Away!\"}", response.body);
+        assertEquals(401, response.status);
+        assertEquals("{\"message\": \"Go Away!\"}", response.body);
     }
 
     @Test
     public void routes_should_be_accept_type_aware() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/hi", null, "application/json");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("{\"message\": \"Hello World\"}", response.body);
+        assertEquals(200, response.status);
+        assertEquals("{\"message\": \"Hello World\"}", response.body);
     }
 
     @Test
     public void template_view_should_be_rendered_with_given_model_view_object() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/templateView", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello from my view", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello from my view", response.body);
     }
 
     @Test
     public void testGetHi() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello World!", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello World!", response.body);
     }
 
     @Test
     public void testGetBinaryHi() {
         try {
             UrlResponse response = testUtil.doMethod("GET", "/binaryhi", null);
-            Assert.assertEquals(200, response.status);
-            Assert.assertEquals("Hello World!", response.body);
+            assertEquals(200, response.status);
+            assertEquals("Hello World!", response.body);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
@@ -255,8 +239,8 @@ public class GenericIntegrationTest {
     public void testGetByteBufferHi() {
         try {
             UrlResponse response = testUtil.doMethod("GET", "/bytebufferhi", null);
-            Assert.assertEquals(200, response.status);
-            Assert.assertEquals("Hello World!", response.body);
+            assertEquals(200, response.status);
+            assertEquals("Hello World!", response.body);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
@@ -266,8 +250,8 @@ public class GenericIntegrationTest {
     public void testGetInputStreamHi() {
         try {
             UrlResponse response = testUtil.doMethod("GET", "/inputstreamhi", null);
-            Assert.assertEquals(200, response.status);
-            Assert.assertEquals("Hello World!", response.body);
+            assertEquals(200, response.status);
+            assertEquals("Hello World!", response.body);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
@@ -276,14 +260,14 @@ public class GenericIntegrationTest {
     @Test
     public void testHiHead() throws Exception {
         UrlResponse response = testUtil.doMethod("HEAD", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("", response.body);
+        assertEquals(200, response.status);
+        assertEquals("", response.body);
     }
 
     @Test
     public void testGetHiAfterFilter() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/hi", null);
-        Assert.assertTrue(response.headers.get("after").contains("foobar"));
+        assertTrue(response.headers.get("after").contains("foobar"));
     }
 
     @Test
@@ -293,38 +277,38 @@ public class GenericIntegrationTest {
         headers.put("X-Forwarded-For", xForwardedFor);
 
         UrlResponse response = testUtil.doMethod("GET", "/ip", null, false, "text/html", headers);
-        Assert.assertEquals(xForwardedFor, response.body);
+        assertEquals(xForwardedFor, response.body);
 
         response = testUtil.doMethod("GET", "/ip", null, false, "text/html", null);
-        Assert.assertNotEquals(xForwardedFor, response.body);
+        assertNotEquals(xForwardedFor, response.body);
     }
 
     @Test
     public void testGetRoot() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello Root!", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello Root!", response.body);
     }
 
     @Test
     public void testParamAndWild() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/paramandwild/thedude/stuff/andits", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("paramandwild: thedudeandits", response.body);
+        assertEquals(200, response.status);
+        assertEquals("paramandwild: thedudeandits", response.body);
     }
 
     @Test
     public void testEchoParam1() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/param/shizzy", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: shizzy", response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: shizzy", response.body);
     }
 
     @Test
     public void testEchoParam2() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/param/gunit", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: gunit", response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: gunit", response.body);
     }
 
     @Test
@@ -332,16 +316,16 @@ public class GenericIntegrationTest {
         String polyglot = "жξ Ä 聊";
         String encoded = URIUtil.encodePath(polyglot);
         UrlResponse response = testUtil.doMethod("GET", "/param/" + encoded, null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: " + polyglot, response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: " + polyglot, response.body);
     }
 
     @Test
     public void testPathParamsWithPlusSign() throws Exception {
         String pathParamWithPlusSign = "not+broken+path+param";
         UrlResponse response = testUtil.doMethod("GET", "/param/" + pathParamWithPlusSign, null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: " + pathParamWithPlusSign, response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: " + pathParamWithPlusSign, response.body);
     }
 
     @Test
@@ -349,8 +333,8 @@ public class GenericIntegrationTest {
         String polyglot = "te/st";
         String encoded = URLEncoder.encode(polyglot, "UTF-8");
         UrlResponse response = testUtil.doMethod("GET", "/param/" + encoded, null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: " + polyglot, response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: " + polyglot, response.body);
     }
 
     @Test
@@ -361,16 +345,16 @@ public class GenericIntegrationTest {
         String encodedSplat = URLEncoder.encode(splat, "UTF-8");
         UrlResponse response = testUtil.doMethod("GET",
                                                  "/paramandwild/" + encodedParam + "/stuff/" + encodedSplat, null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("paramandwild: " + param + splat, response.body);
+        assertEquals(200, response.status);
+        assertEquals("paramandwild: " + param + splat, response.body);
     }
 
     @Test
     public void testEchoParamWithUpperCaseInValue() throws Exception {
         final String camelCased = "ThisIsAValueAndSparkShouldRetainItsUpperCasedCharacters";
         UrlResponse response = testUtil.doMethod("GET", "/param/" + camelCased, null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: " + camelCased, response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: " + camelCased, response.body);
     }
 
     @Test
@@ -385,43 +369,41 @@ public class GenericIntegrationTest {
     }
 
     private static void registerEchoRoute(final String routePart) {
-        get("/tworoutes/" + routePart + "/:param", (q, a) -> {
-            return routePart + " route: " + q.params(":param");
-        });
+        get("/tworoutes/" + routePart + "/:param", (q, a) -> routePart + " route: " + q.params(":param"));
     }
 
     private static void assertEchoRoute(String routePart) throws Exception {
         final String expected = "expected";
         UrlResponse response = testUtil.doMethod("GET", "/tworoutes/" + routePart + "/" + expected, null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(routePart + " route: " + expected, response.body);
+        assertEquals(200, response.status);
+        assertEquals(routePart + " route: " + expected, response.body);
     }
 
     @Test
     public void testEchoParamWithMaj() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/paramwithmaj/plop", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: plop", response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: plop", response.body);
     }
 
     @Test
     public void testUnauthorized() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/secretcontent/whateva", null);
-        Assert.assertTrue(response.status == 401);
+        assertEquals(401, response.status);
     }
 
     @Test
     public void testNotFound() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/no/resource", null);
-        Assert.assertTrue(response.status == 404);
+        assertEquals(404, response.status);
     }
 
     @Test
     public void testPost() throws Exception {
         UrlResponse response = testUtil.doMethod("POST", "/poster", "Fo shizzy");
         LOGGER.info(response.body);
-        Assert.assertEquals(201, response.status);
-        Assert.assertTrue(response.body.contains("Fo shizzy"));
+        assertEquals(201, response.status);
+        assertTrue(response.body.contains("Fo shizzy"));
     }
 
     @Test
@@ -430,63 +412,63 @@ public class GenericIntegrationTest {
         map.put("X-HTTP-Method-Override", "POST");
         UrlResponse response = testUtil.doMethod("GET", "/post_via_get", "Fo shizzy", false, "*/*", map);
         System.out.println(response.body);
-        Assert.assertEquals(201, response.status);
-        Assert.assertTrue(response.body.contains("Method Override Worked"));
+        assertEquals(201, response.status);
+        assertTrue(response.body.contains("Method Override Worked"));
     }
 
     @Test
     public void testPatch() throws Exception {
         UrlResponse response = testUtil.doMethod("PATCH", "/patcher", "Fo shizzy");
         LOGGER.info(response.body);
-        Assert.assertEquals(200, response.status);
-        Assert.assertTrue(response.body.contains("Fo shizzy"));
+        assertEquals(200, response.status);
+        assertTrue(response.body.contains("Fo shizzy"));
     }
 
     @Test
     public void testSessionReset() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/session_reset", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("22222", response.body);
+        assertEquals(200, response.status);
+        assertEquals("22222", response.body);
     }
 
     @Test
     public void testStaticFile() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/css/style.css", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Content of css file", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Content of css file", response.body);
     }
 
     @Test
     public void testExternalStaticFile() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/externalFile.html", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Content of external file", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Content of external file", response.body);
     }
 
     @Test
     public void testExceptionMapper() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/throwexception", null);
-        Assert.assertEquals("Exception handled", response.body);
+        assertEquals("Exception handled", response.body);
     }
 
     @Test
     public void testInheritanceExceptionMapper() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/throwsubclassofbaseexception", null);
-        Assert.assertEquals("Exception handled", response.body);
+        assertEquals("Exception handled", response.body);
     }
 
     @Test
     public void testNotFoundExceptionMapper() throws Exception {
         //        thrownotfound
         UrlResponse response = testUtil.doMethod("GET", "/thrownotfound", null);
-        Assert.assertEquals(NOT_FOUND_BRO, response.body);
-        Assert.assertEquals(404, response.status);
+        assertEquals(NOT_FOUND_BRO, response.body);
+        assertEquals(404, response.status);
     }
 
     @Test
     public void testTypedExceptionMapper() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/throwmeyling", null);
-        Assert.assertEquals(new JWGmeligMeylingException().trustButVerify(), response.body);
+        assertEquals(new JWGmeligMeylingException().trustButVerify(), response.body);
     }
 
     @Test
@@ -504,56 +486,56 @@ public class GenericIntegrationTest {
         }
 
         List<String> events = WebSocketTestHandler.events;
-        Assert.assertEquals(3, events.size(), 3);
-        Assert.assertEquals("onConnect", events.get(0));
-        Assert.assertEquals("onMessage: Hi Spark!", events.get(1));
-        Assert.assertEquals("onClose: 1000 Bye!", events.get(2));
+        assertEquals(3, events.size(), 3);
+        assertEquals("onConnect", events.get(0));
+        assertEquals("onMessage: Hi Spark!", events.get(1));
+        assertEquals("onClose: 1000 Bye!", events.get(2));
     }
 
     @Test
     public void path_should_prefix_routes() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/firstPath/test", null, "application/json");
-        Assert.assertTrue(response.status == 200);
-        Assert.assertEquals("Single path-prefix works", response.body);
-        Assert.assertEquals("true", response.headers.get("before-filter-ran"));
+        assertEquals(200, response.status);
+        assertEquals("Single path-prefix works", response.body);
+        assertEquals("true", response.headers.get("before-filter-ran"));
     }
 
     @Test
     public void paths_should_be_nestable() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/firstPath/secondPath/test", null, "application/json");
-        Assert.assertTrue(response.status == 200);
-        Assert.assertEquals("Nested path-prefix works", response.body);
-        Assert.assertEquals("true", response.headers.get("before-filter-ran"));
+        assertEquals(200, response.status);
+        assertEquals("Nested path-prefix works", response.body);
+        assertEquals("true", response.headers.get("before-filter-ran"));
     }
 
     @Test
     public void paths_should_be_very_nestable() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/firstPath/secondPath/thirdPath/test", null, "application/json");
-        Assert.assertTrue(response.status == 200);
-        Assert.assertEquals("Very nested path-prefix works", response.body);
-        Assert.assertEquals("true", response.headers.get("before-filter-ran"));
+        assertEquals(200, response.status);
+        assertEquals("Very nested path-prefix works", response.body);
+        assertEquals("true", response.headers.get("before-filter-ran"));
     }
 
     @Test
     public void testRuntimeExceptionForDone() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/exception", null);
-        Assert.assertEquals("done executed for exception", response.body);
-        Assert.assertEquals(500, response.status);
+        assertEquals("done executed for exception", response.body);
+        assertEquals(500, response.status);
     }
 
     @Test
     public void testRuntimeExceptionForAllRoutesFinally() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/hi", null);
-        Assert.assertEquals("foobar", response.headers.get("after"));
-        Assert.assertEquals("nice done response after all", response.headers.get("post-process-all"));
-        Assert.assertEquals(200, response.status);
+        assertEquals("foobar", response.headers.get("after"));
+        assertEquals("nice done response after all", response.headers.get("post-process-all"));
+        assertEquals(200, response.status);
     }
 
     @Test
     public void testPostProcessBodyForFinally() throws Exception {
         UrlResponse response = testUtil.doMethod("POST", "/nice", "");
-        Assert.assertEquals("nice response", response.body);
-        Assert.assertEquals("nice done response", response.headers.get("post-process"));
-        Assert.assertEquals(200, response.status);
+        assertEquals("nice response", response.body);
+        assertEquals("nice done response", response.headers.get("post-process"));
+        assertEquals(200, response.status);
     }
 }

--- a/src/test/java/spark/GenericSecureIntegrationTest.java
+++ b/src/test/java/spark/GenericSecureIntegrationTest.java
@@ -2,17 +2,18 @@ package spark;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.after;
 import static spark.Spark.before;
 import static spark.Spark.get;
@@ -26,12 +27,12 @@ public class GenericSecureIntegrationTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericSecureIntegrationTest.class);
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         testUtil = new SparkTestUtil(4567);
 
@@ -41,9 +42,7 @@ public class GenericSecureIntegrationTest {
         Spark.secure(SparkTestUtil.getKeyStoreLocation(),
                      SparkTestUtil.getKeystorePassword(), null, null);
 
-        before("/protected/*", (request, response) -> {
-            halt(401, "Go Away!");
-        });
+        before("/protected/*", (request, response) -> halt(401, "Go Away!"));
 
         get("/hi", (request, response) -> "Hello World!");
 
@@ -67,9 +66,7 @@ public class GenericSecureIntegrationTest {
             return "Body was: " + body;
         });
 
-        after("/hi", (request, response) -> {
-            response.header("after", "foobar");
-        });
+        after("/hi", (request, response) -> response.header("after", "foobar"));
 
         Spark.awaitInitialization();
     }
@@ -77,8 +74,8 @@ public class GenericSecureIntegrationTest {
     @Test
     public void testGetHi() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethodSecure("GET", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello World!", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello World!", response.body);
     }
 
     @Test
@@ -88,79 +85,79 @@ public class GenericSecureIntegrationTest {
         headers.put("X-Forwarded-For", xForwardedFor);
 
         UrlResponse response = testUtil.doMethod("GET", "/ip", null, true, "text/html", headers);
-        Assert.assertEquals(xForwardedFor, response.body);
+        assertEquals(xForwardedFor, response.body);
 
         response = testUtil.doMethod("GET", "/ip", null, true, "text/html", null);
-        Assert.assertNotEquals(xForwardedFor, response.body);
+        assertNotEquals(xForwardedFor, response.body);
     }
 
 
     @Test
     public void testHiHead() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("HEAD", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("", response.body);
+        assertEquals(200, response.status);
+        assertEquals("", response.body);
     }
 
     @Test
     public void testGetHiAfterFilter() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("GET", "/hi", null);
-        Assert.assertTrue(response.headers.get("after").contains("foobar"));
+        assertTrue(response.headers.get("after").contains("foobar"));
     }
 
     @Test
     public void testGetRoot() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("GET", "/", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello Root!", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello Root!", response.body);
     }
 
     @Test
     public void testEchoParam1() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("GET", "/shizzy", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: shizzy", response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: shizzy", response.body);
     }
 
     @Test
     public void testEchoParam2() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("GET", "/gunit", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: gunit", response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: gunit", response.body);
     }
 
     @Test
     public void testEchoParamWithMaj() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("GET", "/paramwithmaj/plop", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("echo: plop", response.body);
+        assertEquals(200, response.status);
+        assertEquals("echo: plop", response.body);
     }
 
     @Test
     public void testUnauthorized() throws Exception {
         UrlResponse urlResponse = testUtil.doMethodSecure("GET", "/protected/resource", null);
-        Assert.assertTrue(urlResponse.status == 401);
+        assertEquals(401, urlResponse.status);
     }
 
     @Test
     public void testNotFound() throws Exception {
         UrlResponse urlResponse = testUtil.doMethodSecure("GET", "/no/resource", null);
-        Assert.assertTrue(urlResponse.status == 404);
+        assertEquals(404, urlResponse.status);
     }
 
     @Test
     public void testPost() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("POST", "/poster", "Fo shizzy");
         LOGGER.info(response.body);
-        Assert.assertEquals(201, response.status);
-        Assert.assertTrue(response.body.contains("Fo shizzy"));
+        assertEquals(201, response.status);
+        assertTrue(response.body.contains("Fo shizzy"));
     }
 
     @Test
     public void testPatch() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("PATCH", "/patcher", "Fo shizzy");
         LOGGER.info(response.body);
-        Assert.assertEquals(200, response.status);
-        Assert.assertTrue(response.body.contains("Fo shizzy"));
+        assertEquals(200, response.status);
+        assertTrue(response.body.contains("Fo shizzy"));
     }
 }

--- a/src/test/java/spark/GzipTest.java
+++ b/src/test/java/spark/GzipTest.java
@@ -16,32 +16,32 @@
  */
 package spark;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import spark.examples.gzip.GzipClient;
 import spark.examples.gzip.GzipExample;
 import spark.util.SparkTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.awaitInitialization;
 import static spark.Spark.stop;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the GZIP compression support in Spark.
  */
 public class GzipTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         GzipExample.addStaticFileLocation();
         GzipExample.addRoutes();
         awaitInitialization();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         stop();
     }
@@ -55,7 +55,7 @@ public class GzipTest {
     @Test
     public void testStaticFileCssStyleCss() throws Exception {
         String decompressed = GzipClient.getAndDecompress("http://localhost:4567/css/style.css");
-        Assert.assertEquals("Content of css file", decompressed);
+        assertEquals("Content of css file", decompressed);
         testGet();
     }
 
@@ -66,8 +66,8 @@ public class GzipTest {
         SparkTestUtil testUtil = new SparkTestUtil(4567);
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hello", "");
 
-        Assert.assertEquals(200, response.status);
-        Assert.assertTrue(response.body.contains(GzipExample.FO_SHIZZY));
+        assertEquals(200, response.status);
+        assertTrue(response.body.contains(GzipExample.FO_SHIZZY));
     }
 
 }

--- a/src/test/java/spark/InitExceptionHandlerTest.java
+++ b/src/test/java/spark/InitExceptionHandlerTest.java
@@ -1,20 +1,20 @@
 package spark;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Service.ignite;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class InitExceptionHandlerTest {
 
-    private static int NON_VALID_PORT = Integer.MAX_VALUE;
+    private static final int NON_VALID_PORT = Integer.MAX_VALUE;
     private static Service service;
     private static String errorMessage = "";
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
+    @BeforeAll
+    public static void setUpClass() {
         service = ignite();
         service.port(NON_VALID_PORT);
         service.initExceptionHandler((e) -> errorMessage = "Custom init error");
@@ -23,11 +23,11 @@ public class InitExceptionHandlerTest {
     }
 
     @Test
-    public void testInitExceptionHandler() throws Exception {
-        Assert.assertEquals("Custom init error", errorMessage);
+    public void testInitExceptionHandler() {
+        assertEquals("Custom init error", errorMessage);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         service.stop();
     }

--- a/src/test/java/spark/MultipleFiltersTest.java
+++ b/src/test/java/spark/MultipleFiltersTest.java
@@ -1,17 +1,17 @@
 package spark;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Spark.after;
 import static spark.Spark.awaitInitialization;
 import static spark.Spark.before;
 import static spark.Spark.get;
 import static spark.Spark.stop;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic test to ensure that multiple before and after filters can be mapped to a route.
@@ -20,8 +20,7 @@ public class MultipleFiltersTest {
     
     private static SparkTestUtil http;
 
-
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         http = new SparkTestUtil(4567);
 
@@ -29,18 +28,18 @@ public class MultipleFiltersTest {
 
         after("/user", incrementCounter, (req, res) -> {
             int counter = req.attribute("counter");
-            Assert.assertEquals(counter, 2);
+            assertEquals(counter, 2);
         });
 
         get("/user", (request, response) -> {
-            Assert.assertEquals((int) request.attribute("counter"), 1);
+            assertEquals((int) request.attribute("counter"), 1);
             return ((User) request.attribute("user")).name();
         });
 
         awaitInitialization();
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopServer() {
         stop();
     }
@@ -49,22 +48,22 @@ public class MultipleFiltersTest {
     public void testMultipleFilters() {
         try {
             SparkTestUtil.UrlResponse response = http.get("/user");
-            Assert.assertEquals(200, response.status);
-            Assert.assertEquals("Kevin", response.body);
+            assertEquals(200, response.status);
+            assertEquals("Kevin", response.body);
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    private static Filter loadUser = (request, response) -> {
+    private static final Filter loadUser = (request, response) -> {
         User u = new User();
         u.name("Kevin");
         request.attribute("user", u);
     };
 
-    private static Filter initializeCounter = (request, response) -> request.attribute("counter", 0);
+    private static final Filter initializeCounter = (request, response) -> request.attribute("counter", 0);
 
-    private static Filter incrementCounter = (request, response) -> {
+    private static final Filter incrementCounter = (request, response) -> {
         int counter = request.attribute("counter");
         counter++;
         request.attribute("counter", counter);

--- a/src/test/java/spark/MultipleServicesTest.java
+++ b/src/test/java/spark/MultipleServicesTest.java
@@ -16,17 +16,19 @@
  */
 package spark;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import spark.route.HttpMethod;
 import spark.routematch.RouteMatch;
 import spark.util.SparkTestUtil;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Service.ignite;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by Per Wendel on 2016-02-18.
@@ -39,7 +41,7 @@ public class MultipleServicesTest {
     private static SparkTestUtil firstClient;
     private static SparkTestUtil secondClient;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         firstClient = new SparkTestUtil(4567);
         secondClient = new SparkTestUtil(1234);
@@ -51,7 +53,7 @@ public class MultipleServicesTest {
         second.awaitInitialization();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         first.stop();
         second.stop();
@@ -60,60 +62,60 @@ public class MultipleServicesTest {
     @Test
     public void testGetHello() throws Exception {
         SparkTestUtil.UrlResponse response = firstClient.doMethod("GET", "/hello", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello World!", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello World!", response.body);
     }
 
     @Test
     public void testGetRedirectedHi() throws Exception {
         SparkTestUtil.UrlResponse response = secondClient.doMethod("GET", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello World!", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello World!", response.body);
     }
 
     @Test
     public void testGetUniqueForSecondWithFirst() throws Exception {
         SparkTestUtil.UrlResponse response = firstClient.doMethod("GET", "/uniqueforsecond", null);
-        Assert.assertEquals(404, response.status);
+        assertEquals(404, response.status);
     }
 
     @Test
     public void testGetUniqueForSecondWithSecond() throws Exception {
         SparkTestUtil.UrlResponse response = secondClient.doMethod("GET", "/uniqueforsecond", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Bompton", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Bompton", response.body);
     }
 
     @Test
     public void testStaticFileCssStyleCssWithFirst() throws Exception {
         SparkTestUtil.UrlResponse response = firstClient.doMethod("GET", "/css/style.css", null);
-        Assert.assertEquals(404, response.status);
+        assertEquals(404, response.status);
     }
 
     @Test
     public void testStaticFileCssStyleCssWithSecond() throws Exception {
         SparkTestUtil.UrlResponse response = secondClient.doMethod("GET", "/css/style.css", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Content of css file", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Content of css file", response.body);
     }
 
     @Test
     public void testGetAllRoutesFromBothServices(){
         for(RouteMatch routeMatch : first.routes()){
-            Assert.assertEquals(routeMatch.getAcceptType(), "*/*");
-            Assert.assertEquals(routeMatch.getHttpMethod(), HttpMethod.get);
-            Assert.assertEquals(routeMatch.getMatchUri(), "/hello");
-            Assert.assertEquals(routeMatch.getRequestURI(), "ALL_ROUTES");
-            Assert.assertThat(routeMatch.getTarget(), instanceOf(RouteImpl.class));
+            assertEquals(routeMatch.getAcceptType(), "*/*");
+            assertEquals(routeMatch.getHttpMethod(), HttpMethod.get);
+            assertEquals(routeMatch.getMatchUri(), "/hello");
+            assertEquals(routeMatch.getRequestURI(), "ALL_ROUTES");
+            assertThat(routeMatch.getTarget(), instanceOf(RouteImpl.class));
         }
 
         for(RouteMatch routeMatch : second.routes()){
-            Assert.assertEquals(routeMatch.getAcceptType(), "*/*");
-            Assert.assertThat(routeMatch.getHttpMethod(), instanceOf(HttpMethod.class));
+            assertEquals(routeMatch.getAcceptType(), "*/*");
+            assertThat(routeMatch.getHttpMethod(), instanceOf(HttpMethod.class));
             boolean isUriOnList = ("/hello/hi/uniqueforsecond").contains(routeMatch.getMatchUri());
-            Assert.assertTrue(isUriOnList);
-            Assert.assertEquals(routeMatch.getRequestURI(), "ALL_ROUTES");
-            Assert.assertThat(routeMatch.getTarget(), instanceOf(RouteImpl.class));
+            assertTrue(isUriOnList);
+            assertEquals(routeMatch.getRequestURI(), "ALL_ROUTES");
+            assertThat(routeMatch.getTarget(), instanceOf(RouteImpl.class));
         }
     }
 

--- a/src/test/java/spark/QueryParamsMapTest.java
+++ b/src/test/java/spark/QueryParamsMapTest.java
@@ -1,18 +1,17 @@
 package spark;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QueryParamsMapTest {
 
-    QueryParamsMap queryMap = new QueryParamsMap();
+    private final QueryParamsMap queryMap = new QueryParamsMap();
     
     @Test
     public void constructorWithParametersMap() {
@@ -55,11 +54,11 @@ public class QueryParamsMapTest {
         queryMap.loadKeys("user[age]",new String[] {"10"});
         queryMap.loadKeys("user[agrees]",new String[] {"true"});
 
-        assertEquals(new Integer(10),queryMap.get("user").get("age").integerValue());
-        assertEquals(new Float(10),queryMap.get("user").get("age").floatValue());
-        assertEquals(new Double(10),queryMap.get("user").get("age").doubleValue());
-        assertEquals(new Long(10),queryMap.get("user").get("age").longValue());
-        assertEquals(Boolean.TRUE,queryMap.get("user").get("agrees").booleanValue());
+        assertEquals(Integer.valueOf(10), queryMap.get("user").get("age").integerValue());
+        assertEquals(Float.valueOf(10.0F), queryMap.get("user").get("age").floatValue());
+        assertEquals(Double.valueOf(10.0D), queryMap.get("user").get("age").doubleValue());
+        assertEquals(Long.valueOf(10), queryMap.get("user").get("age").longValue());
+        assertEquals(Boolean.TRUE, queryMap.get("user").get("agrees").booleanValue());
     }
     
     @Test
@@ -72,9 +71,7 @@ public class QueryParamsMapTest {
     
     @Test
     public void parseKeyShouldParseSubkeys() {
-        String[] parsed = null;
-        
-        parsed = queryMap.parseKey("[name][more]");
+        String[] parsed = queryMap.parseKey("[name][more]");
         
         assertEquals("name",parsed[0]);
         assertEquals("[more]",parsed[1]);

--- a/src/test/java/spark/RedirectTest.java
+++ b/src/test/java/spark/RedirectTest.java
@@ -17,13 +17,11 @@
 package spark;
 
 import java.io.IOException;
-
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Spark.get;
 import static spark.Spark.redirect;
 
@@ -36,7 +34,7 @@ public class RedirectTest {
 
     private static SparkTestUtil testUtil;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
         testUtil.setFollowRedirectStrategy(301, 302); // don't set the others to be able to verify affect of Redirect.Status
@@ -61,105 +59,105 @@ public class RedirectTest {
     @Test
     public void testRedirectGet() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectPost() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("POST", "/hi", "");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectPut() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("PUT", "/hi", "");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectDelete() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("DELETE", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectAnyGet() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/any", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectAnyPut() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("PUT", "/any", "");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectAnyPost() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("POST", "/any", "");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectAnyDelete() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("DELETE", "/any", "");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(REDIRECTED, response.body);
+        assertEquals(200, response.status);
+        assertEquals(REDIRECTED, response.body);
     }
 
     @Test
     public void testRedirectGetWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hiagain", null);
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
     @Test
     public void testRedirectPostWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("POST", "/hiagain", "");
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
     @Test
     public void testRedirectPutWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("PUT", "/hiagain", "");
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
     @Test
     public void testRedirectDeleteWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("DELETE", "/hiagain", null);
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
     @Test
     public void testRedirectAnyGetWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/anyagain", null);
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
     @Test
     public void testRedirectAnyPostWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("POST", "/anyagain", "");
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
     @Test
     public void testRedirectAnyPutWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("PUT", "/anyagain", "");
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
     @Test
     public void testRedirectAnyDeleteWithSpecificCode() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("DELETE", "/anyagain", null);
-        Assert.assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
+        assertEquals(Redirect.Status.USE_PROXY.intValue(), response.status);
     }
 
 }

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -1,22 +1,30 @@
 package spark;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import spark.routematch.RouteMatch;
 import spark.util.SparkTestUtil;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static spark.Spark.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class RequestTest {
 
@@ -29,14 +37,14 @@ public class RequestTest {
 
     private static SparkTestUtil http;
 
-    HttpServletRequest servletRequest;
-    HttpSession httpSession;
-    Request request;
+    private HttpServletRequest servletRequest;
+    private HttpSession httpSession;
+    private Request request;
 
-    RouteMatch match = new RouteMatch(null, "/hi", "/hi", "text/html", null);
-    RouteMatch matchWithParams = new RouteMatch(null, "/users/:username", "/users/bob", "text/html", null);
+    private final RouteMatch match = new RouteMatch(null, "/hi", "/hi", "text/html", null);
+    private final RouteMatch matchWithParams = new RouteMatch(null, "/users/:username", "/users/bob", "text/html", null);
 
-    @Before
+    @BeforeEach
     public void setup() {
         http = new SparkTestUtil(4567);
 
@@ -70,7 +78,7 @@ public class RequestTest {
         when(servletRequest.getParameter("name")).thenReturn("Federico");
 
         String name = request.queryParams("name");
-        assertEquals("Invalid name in query string", "Federico", name);
+        assertEquals("Federico", name, "Invalid name in query string");
     }
 
     @Test
@@ -79,7 +87,7 @@ public class RequestTest {
         when(servletRequest.getParameter("name")).thenReturn("Federico");
 
         String name = request.queryParamOrDefault("name", "David");
-        assertEquals("Invalid name in query string", "Federico", name);
+        assertEquals("Federico", name, "Invalid name in query string");
     }
 
     @Test
@@ -88,7 +96,7 @@ public class RequestTest {
         when(servletRequest.getParameter("name")).thenReturn(null);
 
         String name = request.queryParamOrDefault("name", "David");
-        assertEquals("Invalid name in default value", "David", name);
+        assertEquals("David", name, "Invalid name in default value");
     }
 
     @Test
@@ -99,7 +107,7 @@ public class RequestTest {
         when(servletRequest.getParameterMap()).thenReturn(params);
 
         String name = request.queryMap("user").value("name");
-        assertEquals("Invalid name in query string", "Federico", name);
+        assertEquals("Federico", name, "Invalid name in query string");
     }
 
     @Test
@@ -108,7 +116,7 @@ public class RequestTest {
         when(servletRequest.getServletPath()).thenReturn(THE_SERVLET_PATH);
 
         Request request = new Request(match, servletRequest);
-        assertEquals("Should have delegated getting the servlet path", THE_SERVLET_PATH, request.servletPath());
+        assertEquals(THE_SERVLET_PATH, request.servletPath(), "Should have delegated getting the servlet path");
     }
 
     @Test
@@ -117,13 +125,13 @@ public class RequestTest {
         when(servletRequest.getContextPath()).thenReturn(THE_CONTEXT_PATH);
 
         Request request = new Request(match, servletRequest);
-        assertEquals("Should have delegated getting the context path", THE_CONTEXT_PATH, request.contextPath());
+        assertEquals(THE_CONTEXT_PATH, request.contextPath(), "Should have delegated getting the context path");
     }
 
     @Test
     public void shouldBeAbleToGetTheMatchedPath() {
         Request request = new Request(matchWithParams, servletRequest);
-        assertEquals("Should have returned the matched route", THE_MATCHED_ROUTE, request.matchedPath());
+        assertEquals(THE_MATCHED_ROUTE, request.matchedPath(), "Should have returned the matched route");
         try {
             http.get("/users/bob");
         } catch (Exception e) {
@@ -132,15 +140,15 @@ public class RequestTest {
     }
 
     public void shouldBeAbleToGetTheMatchedPathInBeforeFilter(Request q) {
-        assertEquals("Should have returned the matched route from the before filter", BEFORE_MATCHED_ROUTE, q.matchedPath());
+        assertEquals(BEFORE_MATCHED_ROUTE, q.matchedPath(), "Should have returned the matched route from the before filter");
     }
 
     public void shouldBeAbleToGetTheMatchedPathInAfterFilter(Request q) {
-        assertEquals("Should have returned the matched route from the after filter", AFTER_MATCHED_ROUTE, q.matchedPath());
+        assertEquals(AFTER_MATCHED_ROUTE, q.matchedPath(), "Should have returned the matched route from the after filter");
     }
 
     public void shouldBeAbleToGetTheMatchedPathInAfterAfterFilter(Request q) {
-        assertEquals("Should have returned the matched route from the afterafter filter", AFTERAFTER_MATCHED_ROUTE, q.matchedPath());
+        assertEquals(AFTERAFTER_MATCHED_ROUTE, q.matchedPath(), "Should have returned the matched route from the afterafter filter");
     }
 
     @Test
@@ -148,8 +156,7 @@ public class RequestTest {
 
         when(servletRequest.getSession()).thenReturn(httpSession);
 
-        assertEquals("A Session with an HTTPSession from the Request should have been created",
-                httpSession, request.session().raw());
+        assertEquals(httpSession, request.session().raw(), "A Session with an HTTPSession from the Request should have been created");
     }
 
     @Test
@@ -157,9 +164,8 @@ public class RequestTest {
 
         when(servletRequest.getSession(true)).thenReturn(httpSession);
 
-        assertEquals("A Session with an HTTPSession from the Request should have been created because create parameter " +
-                        "was set to true",
-                httpSession, request.session(true).raw());
+        assertEquals(httpSession, request.session(true).raw(), 
+                "A Session with an HTTPSession from the Request should have been created because create parameter was set to true");
 
     }
 
@@ -168,9 +174,7 @@ public class RequestTest {
 
         when(servletRequest.getSession(true)).thenReturn(httpSession);
 
-        assertEquals("A Session should not have been created because create parameter was set to false",
-                null, request.session(false));
-
+        assertNull(request.session(false), "A Session should not have been created because create parameter was set to false");
     }
 
     @Test
@@ -230,14 +234,13 @@ public class RequestTest {
             expected.put(cookie.getName(), cookie.getValue());
         }
 
-        Cookie[] cookieArray = cookies.toArray(new Cookie[cookies.size()]);
+        Cookie[] cookieArray = cookies.toArray(new Cookie[0]);
 
         when(servletRequest.getCookies()).thenReturn(cookieArray);
 
-        assertTrue("The count of cookies returned should be the same as those in the request",
-                request.cookies().size() == 2);
+        assertEquals(request.cookies().size(), 2, "The count of cookies returned should be the same as those in the request");
 
-        assertEquals("A Map of Cookies should have been returned because they exist", expected, request.cookies());
+        assertEquals(expected, request.cookies(), "A Map of Cookies should have been returned because they exist");
 
     }
 
@@ -246,11 +249,10 @@ public class RequestTest {
 
         when(servletRequest.getCookies()).thenReturn(null);
 
-        assertNotNull("A Map of Cookies should have been instantiated even if cookies are not present in the request",
-                request.cookies());
+        assertNotNull(request.cookies(),
+                "A Map of Cookies should have been instantiated even if cookies are not present in the request");
 
-        assertTrue("The Map of cookies should be empty because cookies are not present in the request",
-                request.cookies().size() == 0);
+        assertTrue(request.cookies().isEmpty(), "The Map of cookies should be empty because cookies are not present in the request");
 
     }
 
@@ -263,14 +265,13 @@ public class RequestTest {
         Collection<Cookie> cookies = new ArrayList<>();
         cookies.add(new Cookie(cookieKey, cookieValue));
 
-        Cookie[] cookieArray = cookies.toArray(new Cookie[cookies.size()]);
+        Cookie[] cookieArray = cookies.toArray(new Cookie[0]);
         when(servletRequest.getCookies()).thenReturn(cookieArray);
 
-        assertNotNull("A value for the key provided should exist because a cookie with the same key is present",
-                request.cookie(cookieKey));
+        assertNotNull(request.cookie(cookieKey),
+            "A value for the key provided should exist because a cookie with the same key is present");
 
-        assertEquals("The correct value for the cookie key supplied should be returned",
-                cookieValue, request.cookie(cookieKey));
+        assertEquals(cookieValue, request.cookie(cookieKey), "The correct value for the cookie key supplied should be returned");
 
     }
 
@@ -281,8 +282,7 @@ public class RequestTest {
 
         when(servletRequest.getCookies()).thenReturn(null);
 
-        assertNull("A null value should have been returned because the cookie with that key does not exist",
-                request.cookie(cookieKey));
+        assertNull(request.cookie(cookieKey), "A null value should have been returned because the cookie with that key does not exist");
 
     }
 
@@ -293,8 +293,7 @@ public class RequestTest {
 
         when(servletRequest.getMethod()).thenReturn(requestMethod);
 
-        assertEquals("The request method of the underlying servlet request should be returned",
-                requestMethod, request.requestMethod());
+        assertEquals(requestMethod, request.requestMethod(), "The request method of the underlying servlet request should be returned");
 
     }
 
@@ -305,8 +304,7 @@ public class RequestTest {
 
         when(servletRequest.getScheme()).thenReturn(scheme);
 
-        assertEquals("The scheme of the underlying servlet request should be returned",
-                scheme, request.scheme());
+        assertEquals(scheme, request.scheme(), "The scheme of the underlying servlet request should be returned");
 
     }
 
@@ -317,8 +315,7 @@ public class RequestTest {
 
         when(servletRequest.getHeader("host")).thenReturn(host);
 
-        assertEquals("The value of the host header of the underlying servlet request should be returned",
-                host, request.host());
+        assertEquals(host, request.host(), "The value of the host header of the underlying servlet request should be returned");
 
     }
 
@@ -329,8 +326,8 @@ public class RequestTest {
 
         when(servletRequest.getHeader("user-agent")).thenReturn(userAgent);
 
-        assertEquals("The value of the user agent header of the underlying servlet request should be returned",
-                userAgent, request.userAgent());
+        assertEquals(userAgent, request.userAgent(), 
+                "The value of the user agent header of the underlying servlet request should be returned");
 
     }
 
@@ -341,8 +338,8 @@ public class RequestTest {
 
         when(servletRequest.getServerPort()).thenReturn(80);
 
-        assertEquals("The server port of the the underlying servlet request should be returned",
-                port, request.port());
+        assertEquals(port, request.port(),
+                "The server port of the the underlying servlet request should be returned");
 
     }
 
@@ -353,8 +350,7 @@ public class RequestTest {
 
         when(servletRequest.getPathInfo()).thenReturn(pathInfo);
 
-        assertEquals("The path info of the underlying servlet request should be returned",
-                pathInfo, request.pathInfo());
+        assertEquals(pathInfo, request.pathInfo(), "The path info of the underlying servlet request should be returned");
 
     }
 
@@ -365,8 +361,7 @@ public class RequestTest {
 
         when(servletRequest.getServletPath()).thenReturn(servletPath);
 
-        assertEquals("The servlet path of the underlying servlet request should be returned",
-                servletPath, request.servletPath());
+        assertEquals(servletPath, request.servletPath(), "The servlet path of the underlying servlet request should be returned");
 
     }
 
@@ -377,8 +372,7 @@ public class RequestTest {
 
         when(servletRequest.getContextPath()).thenReturn(contextPath);
 
-        assertEquals("The context path of the underlying servlet request should be returned",
-                contextPath, request.contextPath());
+        assertEquals(contextPath, request.contextPath(), "The context path of the underlying servlet request should be returned");
 
     }
 
@@ -389,8 +383,7 @@ public class RequestTest {
 
         when(servletRequest.getRequestURL()).thenReturn(new StringBuffer(url));
 
-        assertEquals("The request url of the underlying servlet request should be returned",
-                url, request.url());
+        assertEquals(url, request.url(), "The request url of the underlying servlet request should be returned");
 
     }
 
@@ -401,8 +394,7 @@ public class RequestTest {
 
         when(servletRequest.getContentType()).thenReturn(contentType);
 
-        assertEquals("The content type of the underlying servlet request should be returned",
-                contentType, request.contentType());
+        assertEquals(contentType, request.contentType(), "The content type of the underlying servlet request should be returned");
 
     }
 
@@ -413,8 +405,7 @@ public class RequestTest {
 
         when(servletRequest.getRemoteAddr()).thenReturn(ip);
 
-        assertEquals("The remote IP of the underlying servlet request should be returned",
-                ip, request.ip());
+        assertEquals(ip, request.ip(), "The remote IP of the underlying servlet request should be returned");
 
     }
 
@@ -425,8 +416,7 @@ public class RequestTest {
 
         when(servletRequest.getContentLength()).thenReturn(contentLength);
 
-        assertEquals("The content length the underlying servlet request should be returned",
-                contentLength, request.contentLength());
+        assertEquals(contentLength, request.contentLength(), "The content length the underlying servlet request should be returned");
 
     }
 
@@ -438,8 +428,7 @@ public class RequestTest {
 
         when(servletRequest.getHeader(headerKey)).thenReturn(host);
 
-        assertEquals("The value of the header specified should be returned",
-                host, request.headers(headerKey));
+        assertEquals(host, request.headers(headerKey), "The value of the header specified should be returned");
 
     }
 
@@ -450,8 +439,8 @@ public class RequestTest {
 
         when(servletRequest.getParameterValues("id")).thenReturn(paramValues);
 
-        assertArrayEquals("An array of Strings for a parameter with multiple values should be returned",
-                paramValues, request.queryParamsValues("id"));
+        assertArrayEquals(paramValues, request.queryParamsValues("id"), 
+                "An array of Strings for a parameter with multiple values should be returned");
 
     }
 
@@ -460,8 +449,8 @@ public class RequestTest {
 
         when(servletRequest.getParameterValues("id")).thenReturn(null);
 
-        assertNull("Null should be returned because the parameter specified does not exist in the request",
-                request.queryParamsValues("id"));
+        assertNull(request.queryParamsValues("id"), 
+                "Null should be returned because the parameter specified does not exist in the request");
 
     }
 
@@ -476,7 +465,7 @@ public class RequestTest {
 
         Set<String> result = request.queryParams();
 
-        assertArrayEquals("Should return the query parameter names", params.keySet().toArray(), result.toArray());
+        assertArrayEquals(params.keySet().toArray(), result.toArray(), "Should return the query parameter names");
 
     }
 
@@ -487,8 +476,7 @@ public class RequestTest {
 
         when(servletRequest.getRequestURI()).thenReturn(requestURI);
 
-        assertEquals("The request URI should be returned",
-                requestURI, request.uri());
+        assertEquals(requestURI, request.uri(), "The request URI should be returned");
 
     }
 
@@ -499,8 +487,7 @@ public class RequestTest {
 
         when(servletRequest.getProtocol()).thenReturn(protocol);
 
-        assertEquals("The underlying request protocol should be returned",
-                protocol, request.protocol());
+        assertEquals(protocol, request.protocol(), "The underlying request protocol should be returned");
 
     }
 }

--- a/src/test/java/spark/ResponseBodyTest.java
+++ b/src/test/java/spark/ResponseBodyTest.java
@@ -17,14 +17,12 @@
 package spark;
 
 import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import spark.util.SparkTestUtil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Spark.after;
 import static spark.Spark.get;
 
@@ -45,12 +43,12 @@ public class ResponseBodyTest {
 
     private static SparkTestUtil http;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         http = new SparkTestUtil(4567);
 

--- a/src/test/java/spark/ResponseTest.java
+++ b/src/test/java/spark/ResponseTest.java
@@ -1,7 +1,7 @@
 package spark;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.powermock.reflect.Whitebox;
 
@@ -9,8 +9,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 public class ResponseTest {
@@ -20,7 +20,7 @@ public class ResponseTest {
 
     private ArgumentCaptor<Cookie> cookieArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setup() {
         httpServletResponse = mock(HttpServletResponse.class);
         response = new Response(httpServletResponse);
@@ -30,7 +30,8 @@ public class ResponseTest {
     @Test
     public void testConstructor_whenHttpServletResponseParameter() {
         HttpServletResponse returnResponse = Whitebox.getInternalState(response, "response");
-        assertSame("Should be the same the HttpServletResponse object for httpServletResponse and returnResponse", httpServletResponse, returnResponse);
+        assertSame(httpServletResponse, returnResponse, 
+                "Should be the same the HttpServletResponse object for httpServletResponse and returnResponse");
     }
 
     @Test
@@ -67,7 +68,7 @@ public class ResponseTest {
 
         response.body(finalBody);
         String returnBody = Whitebox.getInternalState(response, "body");
-        assertEquals("Should return body specified", finalBody, returnBody);
+        assertEquals(finalBody, returnBody, "Should return body specified");
     }
 
     @Test
@@ -76,13 +77,14 @@ public class ResponseTest {
 
         Whitebox.setInternalState(response, "body", finalBody);
         String returnBody = response.body();
-        assertEquals("Should return body specified", finalBody, returnBody);
+        assertEquals(finalBody, returnBody, "Should return body specified");
     }
 
     @Test
     public void testRaw() {
         HttpServletResponse returnResponse = response.raw();
-        assertSame("Should be the same the HttpServletResponse object for httpServletResponse and returnResponse", httpServletResponse, returnResponse);
+        assertSame(httpServletResponse, returnResponse, 
+                "Should be the same the HttpServletResponse object for httpServletResponse and returnResponse");
     }
 
     @Test
@@ -128,12 +130,12 @@ public class ResponseTest {
                                        int maxAge,
                                        boolean secured,
                                        boolean httpOnly) {
-        assertEquals("Should return cookie domain specified", domain, cookie.getDomain());
-        assertEquals("Should return cookie path specified", path, cookie.getPath());
-        assertEquals("Should return cookie value specified", value, cookie.getValue());
-        assertEquals("Should return cookie max age specified", maxAge, cookie.getMaxAge());
-        assertEquals("Should return cookie secure specified", secured, cookie.getSecure());
-        assertEquals("Should return cookie http only specified", httpOnly, cookie.isHttpOnly());
+        assertEquals(domain, cookie.getDomain(), "Should return cookie domain specified");
+        assertEquals(path, cookie.getPath(), "Should return cookie path specified");
+        assertEquals(value, cookie.getValue(), "Should return cookie value specified");
+        assertEquals(maxAge, cookie.getMaxAge(), "Should return cookie max age specified");
+        assertEquals(secured, cookie.getSecure(), "Should return cookie secure specified");
+        assertEquals(httpOnly, cookie.isHttpOnly(), "Should return cookie http only specified");
     }
 
     @Test
@@ -264,8 +266,8 @@ public class ResponseTest {
         response.removeCookie(finalName);
         verify(httpServletResponse, times(2)).addCookie(cookieArgumentCaptor.capture());
 
-        assertEquals("Should return empty value for the given cookie name", "", cookieArgumentCaptor.getValue().getValue());
-        assertEquals("Should return an 0 for maximum cookie age", 0, cookieArgumentCaptor.getValue().getMaxAge());
+        assertEquals("", cookieArgumentCaptor.getValue().getValue(), "Should return empty value for the given cookie name");
+        assertEquals(0, cookieArgumentCaptor.getValue().getMaxAge(), "Should return an 0 for maximum cookie age");
     }
 
     @Test

--- a/src/test/java/spark/ResponseWrapperDelegationTest.java
+++ b/src/test/java/spark/ResponseWrapperDelegationTest.java
@@ -1,26 +1,26 @@
 package spark;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
 import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Spark.*;
 
 public class ResponseWrapperDelegationTest {
 
     static SparkTestUtil testUtil;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -47,9 +47,7 @@ public class ResponseWrapperDelegationTest {
             }
         });
 
-        exception(Exception.class, (exception, q, a) -> {
-            exception.printStackTrace();
-        });
+        exception(Exception.class, (exception, q, a) -> exception.printStackTrace());
 
         Spark.awaitInitialization();
     }
@@ -57,15 +55,15 @@ public class ResponseWrapperDelegationTest {
     @Test
     public void filters_can_detect_response_status() throws Exception {
         UrlResponse response = testUtil.get("/204");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("ok", response.body);
+        assertEquals(200, response.status);
+        assertEquals("ok", response.body);
     }
 
     @Test
     public void filters_can_detect_content_type() throws Exception {
         UrlResponse response = testUtil.get("/json");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("{\"status\": \"ok\"}", response.body);
-        Assert.assertEquals("text/plain", response.headers.get("Content-Type"));
+        assertEquals(200, response.status);
+        assertEquals("{\"status\": \"ok\"}", response.body);
+        assertEquals("text/plain", response.headers.get("Content-Type"));
     }
 }

--- a/src/test/java/spark/RouteImplTest.java
+++ b/src/test/java/spark/RouteImplTest.java
@@ -1,10 +1,10 @@
 package spark;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
 
 public class RouteImplTest {
 
@@ -17,32 +17,32 @@ public class RouteImplTest {
     public void testConstructor(){
         route = new RouteImpl(PATH_TEST) {
             @Override
-            public Object handle(Request request, Response response) throws Exception {
+            public Object handle(Request request, Response response) {
                 return null;
             }
         };
-        assertEquals("Should return path specified", PATH_TEST, route.getPath());
+        assertEquals(PATH_TEST, route.getPath(), "Should return path specified");
     }
 
     @Test
-    public void testGets_thenReturnGetPathAndGetAcceptTypeSuccessfully() throws Exception {
+    public void testGets_thenReturnGetPathAndGetAcceptTypeSuccessfully() {
         route = RouteImpl.create(PATH_TEST, ACCEPT_TYPE_TEST, null);
-        assertEquals("Should return path specified", PATH_TEST, route.getPath());
-        assertEquals("Should return accept type specified", ACCEPT_TYPE_TEST, route.getAcceptType());
+        assertEquals(PATH_TEST, route.getPath(), "Should return path specified");
+        assertEquals(ACCEPT_TYPE_TEST, route.getAcceptType(), "Should return accept type specified");
     }
 
     @Test
     public void testCreate_whenOutAssignAcceptTypeInTheParameters_thenReturnPathAndAcceptTypeSuccessfully(){
         route = RouteImpl.create(PATH_TEST, null);
-        assertEquals("Should return path specified", PATH_TEST, route.getPath());
-        assertEquals("Should return the default accept type", RouteImpl.DEFAULT_ACCEPT_TYPE, route.getAcceptType());
+        assertEquals(PATH_TEST, route.getPath(), "Should return path specified");
+        assertEquals(RouteImpl.DEFAULT_ACCEPT_TYPE, route.getAcceptType(), "Should return the default accept type");
     }
 
     @Test
     public void testCreate_whenAcceptTypeNullValueInTheParameters_thenReturnPathAndAcceptTypeSuccessfully(){
         route = RouteImpl.create(PATH_TEST, null, null);
-        assertEquals("Should return path specified", PATH_TEST, route.getPath());
-        assertEquals("Should return the default accept type", RouteImpl.DEFAULT_ACCEPT_TYPE, route.getAcceptType());
+        assertEquals(PATH_TEST, route.getPath(), "Should return path specified");
+        assertEquals(RouteImpl.DEFAULT_ACCEPT_TYPE, route.getAcceptType(), "Should return the default accept type");
     }
 
     @Test
@@ -50,14 +50,14 @@ public class RouteImplTest {
         String finalObjValue = "object_value";
         route = RouteImpl.create(PATH_TEST, null);
         Object value = route.render(finalObjValue);
-        assertNotNull("Should return an Object because we configured it to have one", value);
-        assertEquals("Should return a string object specified", finalObjValue, value.toString());
+        assertNotNull(value, "Should return an Object because we configured it to have one");
+        assertEquals(finalObjValue, value.toString(), "Should return a string object specified");
     }
 
     @Test
     public void testRender_whenElementParameterIsNull_thenReturnNull() throws Exception {
         route = RouteImpl.create(PATH_TEST, null);
         Object value = route.render(null);
-        assertNull("Should return null because the element from render is null", value);
+        assertNull(value, "Should return null because the element from render is null");
     }
 }

--- a/src/test/java/spark/ServicePortIntegrationTest.java
+++ b/src/test/java/spark/ServicePortIntegrationTest.java
@@ -1,13 +1,13 @@
 package spark;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Service.ignite;
 
 /**
@@ -18,8 +18,8 @@ public class ServicePortIntegrationTest {
     private static Service service;
     private static final Logger LOGGER = LoggerFactory.getLogger(ServicePortIntegrationTest.class);
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
+    @BeforeAll
+    public static void setUpClass() {
         service = ignite();
         service.port(0);
 
@@ -37,11 +37,11 @@ public class ServicePortIntegrationTest {
         SparkTestUtil testUtil = new SparkTestUtil(actualPort);
 
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hi", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Hello World!", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Hello World!", response.body);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         service.stop();
     }

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -3,82 +3,75 @@ package spark;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
-
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.EmbeddedServers;
 import spark.route.Routes;
 import spark.ssl.SslStores;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static spark.Service.ignite;
 
 public class ServiceTest {
 
     private static final String IP_ADDRESS = "127.0.0.1";
+    private static final int PORT = 8080;
     private static final int NOT_FOUND_STATUS_CODE = HttpServletResponse.SC_NOT_FOUND;
 
     private Service service;
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
+    @BeforeEach
     public void test() {
         service = ignite();
     }
 
     @Test
     public void testEmbeddedServerIdentifier_defaultAndSet() {
-        assertEquals("Should return defaultIdentifier()",
-            EmbeddedServers.defaultIdentifier(),
-            service.embeddedServerIdentifier());
+        assertEquals(EmbeddedServers.defaultIdentifier(), service.embeddedServerIdentifier(), "Should return defaultIdentifier()");
 
         Object obj = new Object();
 
         service.embeddedServerIdentifier(obj);
 
-        assertEquals("Should return expected obj",
-            obj,
-            service.embeddedServerIdentifier());
+        assertEquals(obj, service.embeddedServerIdentifier(), "Should return expected obj");
     }
 
     @Test
     public void testEmbeddedServerIdentifier_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Object obj = new Object();
 
         Whitebox.setInternalState(service, "initialized", true);
-        service.embeddedServerIdentifier(obj);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.embeddedServerIdentifier(obj));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
-    @Test(expected = HaltException.class)
+    @Test
     public void testHalt_whenOutParameters_thenThrowHaltException() {
-        service.halt();
+        assertThrows(HaltException.class, () -> service.halt());
     }
 
-    @Test(expected = HaltException.class)
+    @Test
     public void testHalt_whenStatusCode_thenThrowHaltException() {
-        service.halt(NOT_FOUND_STATUS_CODE);
+        assertThrows(HaltException.class, () -> service.halt(NOT_FOUND_STATUS_CODE));
     }
 
-    @Test(expected = HaltException.class)
+    @Test
     public void testHalt_whenBodyContent_thenThrowHaltException() {
-        service.halt("error");
+        assertThrows(HaltException.class, () -> service.halt("error"));
     }
 
-    @Test(expected = HaltException.class)
+    @Test
     public void testHalt_whenStatusCodeAndBodyContent_thenThrowHaltException() {
-        service.halt(NOT_FOUND_STATUS_CODE, "error");
+        assertThrows(HaltException.class, () -> service.halt(NOT_FOUND_STATUS_CODE, "error"));
     }
 
     @Test
@@ -86,16 +79,15 @@ public class ServiceTest {
         service.ipAddress(IP_ADDRESS);
 
         String ipAddress = Whitebox.getInternalState(service, "ipAddress");
-        assertEquals("IP address should be set to the IP address that was specified", IP_ADDRESS, ipAddress);
+        assertEquals(IP_ADDRESS, ipAddress, "IP address should be set to the IP address that was specified");
     }
 
     @Test
     public void testIpAddress_whenInitializedTrue_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.ipAddress(IP_ADDRESS);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.ipAddress(IP_ADDRESS));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
     @Test
@@ -103,70 +95,65 @@ public class ServiceTest {
         service.ipAddress(IP_ADDRESS);
 
         String ipAddress = Whitebox.getInternalState(service, "ipAddress");
-        assertEquals("IP address should be set to the IP address that was specified", IP_ADDRESS, ipAddress);
+        assertEquals(IP_ADDRESS, ipAddress, "IP address should be set to the IP address that was specified");
     }
 
     @Test
     public void testSetIpAddress_whenInitializedTrue_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.ipAddress(IP_ADDRESS);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.ipAddress(IP_ADDRESS));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
     @Test
     public void testPort_whenInitializedFalse() {
-        service.port(8080);
+        service.port(PORT);
 
         int port = Whitebox.getInternalState(service, "port");
-        assertEquals("Port should be set to the Port that was specified", 8080, port);
+        assertEquals(PORT, port, "Port should be set to the Port that was specified");
     }
 
     @Test
     public void testPort_whenInitializedTrue_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.port(8080);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.port(PORT));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
     @Test
     public void testSetPort_whenInitializedFalse() {
-        service.port(8080);
+        service.port(PORT);
 
         int port = Whitebox.getInternalState(service, "port");
-        assertEquals("Port should be set to the Port that was specified", 8080, port);
+        assertEquals(PORT, port, "Port should be set to the Port that was specified");
     }
 
     @Test
     public void testSetPort_whenInitializedTrue_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.port(8080);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.port(PORT));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
     @Test
     public void testGetPort_whenInitializedFalse_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done after route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", false);
-        service.port();
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.port());
+        assertEquals("This must be done after route mapping has begun", ex.getMessage());
     }
 
     @Test
     public void testGetPort_whenInitializedTrue() {
-        int expectedPort = 8080;
         Whitebox.setInternalState(service, "initialized", true);
-        Whitebox.setInternalState(service, "port", expectedPort);
+        Whitebox.setInternalState(service, "port", PORT);
 
         int actualPort = service.port();
 
-        assertEquals("Port retrieved should be the port setted", expectedPort, actualPort);
+        assertEquals(PORT, actualPort, "Port retrieved should be the port setted");
     }
 
     @Test
@@ -176,7 +163,7 @@ public class ServiceTest {
 
         int actualPort = service.port();
 
-        assertEquals("Port retrieved should be the port setted", expectedPort, actualPort);
+        assertEquals(expectedPort, actualPort, "Port retrieved should be the port setted");
     }
 
     @Test
@@ -185,9 +172,9 @@ public class ServiceTest {
         int maxThreads = Whitebox.getInternalState(service, "maxThreads");
         int minThreads = Whitebox.getInternalState(service, "minThreads");
         int threadIdleTimeoutMillis = Whitebox.getInternalState(service, "threadIdleTimeoutMillis");
-        assertEquals("Should return maxThreads specified", 100, maxThreads);
-        assertEquals("Should return minThreads specified", -1, minThreads);
-        assertEquals("Should return threadIdleTimeoutMillis specified", -1, threadIdleTimeoutMillis);
+        assertEquals(100, maxThreads, "Should return maxThreads specified");
+        assertEquals(-1, minThreads, "Should return minThreads specified");
+        assertEquals(-1, threadIdleTimeoutMillis, "Should return threadIdleTimeoutMillis specified");
     }
 
     @Test
@@ -196,81 +183,74 @@ public class ServiceTest {
         int maxThreads = Whitebox.getInternalState(service, "maxThreads");
         int minThreads = Whitebox.getInternalState(service, "minThreads");
         int threadIdleTimeoutMillis = Whitebox.getInternalState(service, "threadIdleTimeoutMillis");
-        assertEquals("Should return maxThreads specified", 100, maxThreads);
-        assertEquals("Should return minThreads specified", 50, minThreads);
-        assertEquals("Should return threadIdleTimeoutMillis specified", 75, threadIdleTimeoutMillis);
+        assertEquals(100, maxThreads, "Should return maxThreads specified");
+        assertEquals(50, minThreads, "Should return minThreads specified");
+        assertEquals(75, threadIdleTimeoutMillis, "Should return threadIdleTimeoutMillis specified");
     }
 
     @Test
     public void testThreadPool_whenMaxMinAndTimeoutParameters_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.threadPool(100, 50, 75);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.threadPool(100, 50, 75));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
     @Test
     public void testSecure_thenReturnNewSslStores() {
         service.secure("keyfile", "keypassword", "truststorefile", "truststorepassword");
         SslStores sslStores = Whitebox.getInternalState(service, "sslStores");
-        assertNotNull("Should return a SslStores because we configured it to have one", sslStores);
-        assertEquals("Should return keystoreFile from SslStores", "keyfile", sslStores.keystoreFile());
-        assertEquals("Should return keystorePassword from SslStores", "keypassword", sslStores.keystorePassword());
-        assertEquals("Should return trustStoreFile from SslStores", "truststorefile", sslStores.trustStoreFile());
-        assertEquals("Should return trustStorePassword from SslStores", "truststorepassword", sslStores.trustStorePassword());
+        assertNotNull(sslStores, "Should return a SslStores because we configured it to have one");
+        assertEquals("keyfile", sslStores.keystoreFile(), "Should return keystoreFile from SslStores");
+        assertEquals("keypassword", sslStores.keystorePassword(), "Should return keystorePassword from SslStores");
+        assertEquals("truststorefile", sslStores.trustStoreFile(), "Should return trustStoreFile from SslStores");
+        assertEquals("truststorepassword", sslStores.trustStorePassword(), "Should return trustStorePassword from SslStores");
     }
 
     @Test
     public void testSecure_whenInitializedTrue_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.secure(null, null, null, null);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.secure(null, null, null, null));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
     @Test
     public void testSecure_whenInitializedFalse_thenThrowIllegalArgumentException() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Must provide a keystore file to run secured");
-
-        service.secure(null, null, null, null);
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.secure(null, null, null, null));
+        assertEquals("Must provide a keystore file to run secured", ex.getMessage());
     }
 
     @Test
     public void testWebSocketIdleTimeoutMillis_whenInitializedTrue_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.webSocketIdleTimeoutMillis(100);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.webSocketIdleTimeoutMillis(100));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
 
     @Test
     public void testWebSocket_whenInitializedTrue_thenThrowIllegalStateException() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This must be done before route mapping has begun");
-
         Whitebox.setInternalState(service, "initialized", true);
-        service.webSocket("/", DummyWebSocketListener.class);
+        
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.webSocket("/", DummyWebSocketListener.class));
+        assertEquals("This must be done before route mapping has begun", ex.getMessage());
     }
     
     @Test
     public void testWebSocket_whenPathNull_thenThrowNullPointerException() {
-        thrown.expect(NullPointerException.class);
-        thrown.expectMessage("WebSocket path cannot be null");
-        service.webSocket(null, new DummyWebSocketListener());
+        final NullPointerException ex = assertThrows(NullPointerException.class, () -> service.webSocket(null, new DummyWebSocketListener()));
+        assertEquals("WebSocket path cannot be null", ex.getMessage());
     }
     
     @Test
     public void testWebSocket_whenHandlerNull_thenThrowNullPointerException() {
-        thrown.expect(NullPointerException.class);
-        thrown.expectMessage("WebSocket handler class cannot be null");
-        service.webSocket("/", null);
+        final NullPointerException ex = assertThrows(NullPointerException.class, () -> service.webSocket("/", null));
+        assertEquals("WebSocket handler class cannot be null", ex.getMessage());
     }
     
-    @Test(timeout = 300)
+    @Test
+    @Timeout(value = 300, unit = MILLISECONDS)
     public void stopExtinguishesServer() {
         Service service = Service.ignite();
         Routes routes = Mockito.mock(Routes.class);

--- a/src/test/java/spark/SessionTest.java
+++ b/src/test/java/spark/SessionTest.java
@@ -1,7 +1,7 @@
 package spark;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import javax.servlet.http.HttpSession;
@@ -10,8 +10,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class SessionTest {
@@ -20,7 +21,7 @@ public class SessionTest {
     HttpSession httpSession;
     Session session;
 
-    @Before
+    @BeforeEach
     public void setup() {
 
         httpSession = mock(HttpSession.class);
@@ -30,28 +31,20 @@ public class SessionTest {
 
     @Test
     public void testSession_whenHttpSessionIsNull_thenThrowException() {
-
         try {
-
             new Session(null, request);
             fail("Session instantiation with a null HttpSession should throw an IllegalArgumentException");
-
         } catch (IllegalArgumentException ex) {
-
             assertEquals("session cannot be null", ex.getMessage());
         }
     }
 
     @Test
     public void testSession_whenRequestIsNull_thenThrowException() {
-
         try {
-
             new Session(httpSession, null);
             fail("Session instantiation with a null Request should throw an IllegalArgumentException");
-
         } catch (IllegalArgumentException ex) {
-
             assertEquals("request cannot be null", ex.getMessage());
         }
     }
@@ -60,15 +53,13 @@ public class SessionTest {
     public void testSession() {
 
         HttpSession internalSession = Whitebox.getInternalState(session, "session");
-        assertEquals("Internal session should be set to the http session provided during instantiation",
-                httpSession, internalSession);
+        assertEquals(httpSession, internalSession, "Internal session should be set to the http session provided during instantiation");
     }
 
     @Test
     public void testRaw() {
 
-        assertEquals("Should return the HttpSession provided during instantiation",
-                httpSession, session.raw());
+        assertEquals(httpSession, session.raw(), "Should return the HttpSession provided during instantiation");
     }
 
     @Test
@@ -76,7 +67,7 @@ public class SessionTest {
 
         when(httpSession.getAttribute("name")).thenReturn("Jett");
 
-        assertEquals("Should return attribute from HttpSession", "Jett", session.attribute("name"));
+        assertEquals("Jett", session.attribute("name"), "Should return attribute from HttpSession");
 
     }
 
@@ -95,15 +86,15 @@ public class SessionTest {
 
         when(httpSession.getAttributeNames()).thenReturn(Collections.enumeration(attributes));
 
-        assertEquals("Should return attributes from the HttpSession", attributes, session.attributes());
+        assertEquals(attributes, session.attributes(), "Should return attributes from the HttpSession");
     }
 
     @Test
     public void testCreationTime() {
 
-        when(httpSession.getCreationTime()).thenReturn(10000000l);
+        when(httpSession.getCreationTime()).thenReturn(10000000L);
 
-        assertEquals("Should return creationTime from HttpSession", 10000000l, session.creationTime());
+        assertEquals(10000000L, session.creationTime(), "Should return creationTime from HttpSession");
     }
 
     @Test
@@ -111,15 +102,15 @@ public class SessionTest {
 
         when(httpSession.getId()).thenReturn("id");
 
-        assertEquals("Should return session id from HttpSession", "id", session.id());
+        assertEquals("id", session.id(), "Should return session id from HttpSession");
     }
 
     @Test
     public void testLastAccessedTime() {
 
-        when(httpSession.getLastAccessedTime()).thenReturn(20000000l);
+        when(httpSession.getLastAccessedTime()).thenReturn(20000000L);
 
-        assertEquals("Should return lastAccessedTime from HttpSession", 20000000l, session.lastAccessedTime());
+        assertEquals(20000000L, session.lastAccessedTime(), "Should return lastAccessedTime from HttpSession");
     }
 
     @Test
@@ -127,7 +118,7 @@ public class SessionTest {
 
         when(httpSession.getMaxInactiveInterval()).thenReturn(100);
 
-        assertEquals("Should return maxInactiveInterval from HttpSession", 100, session.maxInactiveInterval());
+        assertEquals(100, session.maxInactiveInterval(), "Should return maxInactiveInterval from HttpSession");
     }
 
     @Test
@@ -151,7 +142,7 @@ public class SessionTest {
 
         when(httpSession.isNew()).thenReturn(true);
 
-        assertEquals("Should return isNew status from HttpSession", true, session.isNew());
+        assertTrue(session.isNew(), "Should return isNew status from HttpSession");
     }
 
     @Test

--- a/src/test/java/spark/StaticFilesFromArchiveTest.java
+++ b/src/test/java/spark/StaticFilesFromArchiveTest.java
@@ -18,16 +18,14 @@ package spark;
 
 import static java.lang.ClassLoader.getSystemClassLoader;
 import static java.lang.System.arraycopy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
@@ -37,7 +35,7 @@ public class StaticFilesFromArchiveTest {
     private static ClassLoader classLoader;
     private static ClassLoader initialClassLoader;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         setupClassLoader();
         testUtil = new SparkTestUtil(4567);
@@ -54,12 +52,12 @@ public class StaticFilesFromArchiveTest {
         awaitInitializationMethod.invoke(null);
     }
 
-    @AfterClass
+    @AfterAll
     public static void resetClassLoader() {
         Thread.currentThread().setContextClassLoader(initialClassLoader);
     }
 
-    private static void setupClassLoader() throws Exception {
+    private static void setupClassLoader() {
         ClassLoader extendedClassLoader = createExtendedClassLoader();
         initialClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(extendedClassLoader);

--- a/src/test/java/spark/StaticFilesMemberTest.java
+++ b/src/test/java/spark/StaticFilesMemberTest.java
@@ -20,17 +20,17 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import spark.examples.exception.NotFoundException;
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.exception;
 import static spark.Spark.get;
 import static spark.Spark.staticFiles;
@@ -53,7 +53,7 @@ public class StaticFilesMemberTest {
 
     private static File tmpExternalFile;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
         if (tmpExternalFile != null) {
@@ -62,7 +62,7 @@ public class StaticFilesMemberTest {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -93,8 +93,8 @@ public class StaticFilesMemberTest {
     @Test
     public void testStaticFileCssStyleCss() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/css/style.css", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Content of css file", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Content of css file", response.body);
 
         testGet();
     }
@@ -104,17 +104,17 @@ public class StaticFilesMemberTest {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/js/module.mjs", null);
 
         String expectedContentType = response.headers.get("Content-Type");
-        Assert.assertEquals(expectedContentType, "application/javascript");
+        assertEquals(expectedContentType, "application/javascript");
 
         String body = response.body;
-        Assert.assertEquals("export default function () { console.log(\"Hello, I'm a .mjs file\"); }\n", body);
+        assertEquals("export default function () { console.log(\"Hello, I'm a .mjs file\"); }\n", body);
     }
 
     @Test
     public void testStaticFilePagesIndexHtml() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/pages/index.html", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("<html><body>Hello Static World!</body></html>", response.body);
+        assertEquals(200, response.status);
+        assertEquals("<html><body>Hello Static World!</body></html>", response.body);
 
         testGet();
     }
@@ -122,8 +122,8 @@ public class StaticFilesMemberTest {
     @Test
     public void testStaticFilePageHtml() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/page.html", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("<html><body>Hello Static Files World!</body></html>", response.body);
+        assertEquals(200, response.status);
+        assertEquals("<html><body>Hello Static Files World!</body></html>", response.body);
 
         testGet();
     }
@@ -131,23 +131,24 @@ public class StaticFilesMemberTest {
     @Test
     public void testExternalStaticFile() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/externalFile.html", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("Content of external file", response.body);
+        assertEquals(200, response.status);
+        assertEquals("Content of external file", response.body);
 
         testGet();
     }
 
     @Test
     public void testStaticFileHeaders() throws Exception {
-        staticFiles.headers(new HashMap() {
+        staticFiles.headers(new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
             {
                 put("Server", "Microsoft Word");
                 put("Cache-Control", "private, max-age=600");
             }
         });
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/pages/index.html", null);
-        Assert.assertEquals("Microsoft Word", response.headers.get("Server"));
-        Assert.assertEquals("private, max-age=600", response.headers.get("Cache-Control"));
+        assertEquals("Microsoft Word", response.headers.get("Server"));
+        assertEquals("private, max-age=600", response.headers.get("Cache-Control"));
 
         testGet();
     }
@@ -156,7 +157,7 @@ public class StaticFilesMemberTest {
     public void testStaticFileExpireTime() throws Exception {
         staticFiles.expireTime(600);
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/pages/index.html", null);
-        Assert.assertEquals("private, max-age=600", response.headers.get("Cache-Control"));
+        assertEquals("private, max-age=600", response.headers.get("Cache-Control"));
 
         testGet();
     }
@@ -167,15 +168,15 @@ public class StaticFilesMemberTest {
     private static void testGet() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hello", "");
 
-        Assert.assertEquals(200, response.status);
-        Assert.assertTrue(response.body.contains(FO_SHIZZY));
+        assertEquals(200, response.status);
+        assertTrue(response.body.contains(FO_SHIZZY));
     }
 
     @Test
     public void testExceptionMapping404() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/filethatdoesntexist.html", null);
 
-        Assert.assertEquals(404, response.status);
-        Assert.assertEquals(NOT_FOUND_BRO, response.body);
+        assertEquals(404, response.status);
+        assertEquals(NOT_FOUND_BRO, response.body);
     }
 }

--- a/src/test/java/spark/UnmapTest.java
+++ b/src/test/java/spark/UnmapTest.java
@@ -1,17 +1,17 @@
 package spark;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Spark.awaitInitialization;
 import static spark.Spark.get;
 import static spark.Spark.unmap;
 
+import org.junit.jupiter.api.Test;
+
 public class UnmapTest {
 
-    SparkTestUtil testUtil = new SparkTestUtil(4567);
+    private final SparkTestUtil testUtil = new SparkTestUtil(4567);
 
     @Test
     public void testUnmap() throws Exception {
@@ -19,23 +19,23 @@ public class UnmapTest {
         awaitInitialization();
 
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/tobeunmapped", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("tobeunmapped", response.body);
+        assertEquals(200, response.status);
+        assertEquals("tobeunmapped", response.body);
 
         unmap("/tobeunmapped");
 
         response = testUtil.doMethod("GET", "/tobeunmapped", null);
-        Assert.assertEquals(404, response.status);
+        assertEquals(404, response.status);
 
         get("/tobeunmapped", (q, a) -> "tobeunmapped");
 
         response = testUtil.doMethod("GET", "/tobeunmapped", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("tobeunmapped", response.body);
+        assertEquals(200, response.status);
+        assertEquals("tobeunmapped", response.body);
 
         unmap("/tobeunmapped", "get");
 
         response = testUtil.doMethod("GET", "/tobeunmapped", null);
-        Assert.assertEquals(404, response.status);
+        assertEquals(404, response.status);
     }
 }

--- a/src/test/java/spark/customerrorpages/CustomErrorPagesTest.java
+++ b/src/test/java/spark/customerrorpages/CustomErrorPagesTest.java
@@ -1,16 +1,14 @@
 package spark.customerrorpages;
 
 import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import spark.CustomErrorPages;
 import spark.Spark;
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spark.Spark.get;
 import static spark.Spark.internalServerError;
 import static spark.Spark.notFound;
@@ -25,12 +23,12 @@ public class CustomErrorPagesTest {
 
     static SparkTestUtil testUtil;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -56,30 +54,30 @@ public class CustomErrorPagesTest {
     @Test
     public void testGetHi() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hello", null);
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(HELLO_WORLD, response.body);
+        assertEquals(200, response.status);
+        assertEquals(HELLO_WORLD, response.body);
     }
 
     @Test
     public void testCustomNotFound() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/othernotmapped", null);
-        Assert.assertEquals(404, response.status);
-        Assert.assertEquals(CUSTOM_NOT_FOUND, response.body);
+        assertEquals(404, response.status);
+        assertEquals(CUSTOM_NOT_FOUND, response.body);
     }
 
     @Test
     public void testCustomInternal() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/raiseinternal", null);
-        Assert.assertEquals(500, response.status);
-        Assert.assertEquals(APPLICATION_JSON, response.headers.get("Content-Type"));
-        Assert.assertEquals(CUSTOM_INTERNAL, response.body);
+        assertEquals(500, response.status);
+        assertEquals(APPLICATION_JSON, response.headers.get("Content-Type"));
+        assertEquals(CUSTOM_INTERNAL, response.body);
     }
 
     @Test
     public void testCustomInternalFailingRoute() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/raiseinternal?" + QUERY_PARAM_KEY + "=sumthin", null);
-        Assert.assertEquals(500, response.status);
-        Assert.assertEquals(CustomErrorPages.INTERNAL_ERROR, response.body);
+        assertEquals(500, response.status);
+        assertEquals(CustomErrorPages.INTERNAL_ERROR, response.body);
     }
 
 }

--- a/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
+++ b/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
@@ -5,31 +5,25 @@ import java.io.File;
 import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ThreadPool;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import spark.Spark;
 import spark.embeddedserver.jetty.EmbeddedJettyFactory;
 import spark.embeddedserver.jetty.JettyServerFactory;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class EmbeddedServersTest {
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
     @Test
-    public void testAddAndCreate_whenCreate_createsCustomServer() throws Exception {
+    public void testAddAndCreate_whenCreate_createsCustomServer(@TempDir File requestLogDir) throws Exception {
         // Create custom Server
         Server server = new Server();
-        File requestLogDir = temporaryFolder.newFolder();
         File requestLogFile = new File(requestLogDir, "request.log");
         server.setRequestLog(new NCSARequestLog(requestLogFile.getAbsolutePath()));
         JettyServerFactory serverFactory = mock(JettyServerFactory.class);
@@ -51,8 +45,7 @@ public class EmbeddedServersTest {
     }
 
     @Test
-    public void testAdd_whenConfigureRoutes_createsCustomServer() throws Exception {
-        File requestLogDir = temporaryFolder.newFolder();
+    public void testAdd_whenConfigureRoutes_createsCustomServer(@TempDir File requestLogDir) {
         File requestLogFile = new File(requestLogDir, "request.log");
         // Register custom server
         EmbeddedServers.add(EmbeddedServers.Identifiers.JETTY, new EmbeddedJettyFactory(new JettyServerFactory() {
@@ -74,7 +67,7 @@ public class EmbeddedServersTest {
         assertTrue(requestLogFile.exists());
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
     }

--- a/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
@@ -2,16 +2,15 @@ package spark.embeddedserver.jetty;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.After;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import spark.ExceptionMapper;
 import spark.embeddedserver.EmbeddedServer;
 import spark.route.Routes;
 import spark.staticfiles.StaticFilesConfiguration;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -99,7 +98,7 @@ public class EmbeddedJettyFactoryTest {
         assertFalse(((JettyHandler) server.getHandler()).getSessionCookieConfig().isHttpOnly());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (embeddedServer != null) {
             embeddedServer.extinguish();

--- a/src/test/java/spark/embeddedserver/jetty/JettyServerTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/JettyServerTest.java
@@ -1,12 +1,12 @@
 package spark.embeddedserver.jetty;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class JettyServerTest {
     @Test
@@ -19,9 +19,9 @@ public class JettyServerTest {
         int maxThreads = Whitebox.getInternalState(threadPool, "_maxThreads");
         int idleTimeout = Whitebox.getInternalState(threadPool, "_idleTimeout");
 
-        assertEquals("Server thread pool default minThreads should be 8", 8, minThreads);
-        assertEquals("Server thread pool default maxThreads should be 200", 200, maxThreads);
-        assertEquals("Server thread pool default idleTimeout should be 60000", 60000, idleTimeout);
+        assertEquals(8, minThreads, "Server thread pool default minThreads should be 8");
+        assertEquals(200, maxThreads, "Server thread pool default maxThreads should be 200");
+        assertEquals(60000, idleTimeout, "Server thread pool default idleTimeout should be 60000");
     }
 
     @Test
@@ -34,9 +34,9 @@ public class JettyServerTest {
         int maxThreads = Whitebox.getInternalState(threadPool, "_maxThreads");
         int idleTimeout = Whitebox.getInternalState(threadPool, "_idleTimeout");
 
-        assertEquals("Server thread pool default minThreads should be 8", 8, minThreads);
-        assertEquals("Server thread pool default maxThreads should be the same as specified", 9, maxThreads);
-        assertEquals("Server thread pool default idleTimeout should be 60000", 60000, idleTimeout);
+        assertEquals(8, minThreads, "Server thread pool default minThreads should be 8");
+        assertEquals(9, maxThreads, "Server thread pool default maxThreads should be the same as specified");
+        assertEquals(60000, idleTimeout, "Server thread pool default idleTimeout should be 60000");
 
     }
 

--- a/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactoryTest.java
@@ -1,15 +1,14 @@
 package spark.embeddedserver.jetty.websocket;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import spark.embeddedserver.jetty.websocket.WebSocketCreatorFactory.SparkWebSocketCreator;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class WebSocketCreatorFactoryTest {
 
@@ -18,12 +17,12 @@ public class WebSocketCreatorFactoryTest {
         WebSocketCreator annotated =
                 WebSocketCreatorFactory.create(new WebSocketHandlerClassWrapper(AnnotatedHandler.class));
         assertTrue(annotated instanceof SparkWebSocketCreator);
-        assertTrue(SparkWebSocketCreator.class.cast(annotated).getHandler() instanceof AnnotatedHandler);
+        assertTrue(((SparkWebSocketCreator) annotated).getHandler() instanceof AnnotatedHandler);
 
         WebSocketCreator listener =
                 WebSocketCreatorFactory.create(new WebSocketHandlerClassWrapper(ListenerHandler.class));
         assertTrue(listener instanceof SparkWebSocketCreator);
-        assertTrue(SparkWebSocketCreator.class.cast(listener).getHandler() instanceof ListenerHandler);
+        assertTrue(((SparkWebSocketCreator) listener).getHandler() instanceof ListenerHandler);
     }
 
     @Test
@@ -39,7 +38,7 @@ public class WebSocketCreatorFactoryTest {
     }
 
     @Test
-    public void testCreate_whenInstantiationException() throws Exception {
+    public void testCreate_whenInstantiationException() {
         try {
             WebSocketCreatorFactory.create(new WebSocketHandlerClassWrapper(FailingHandler.class));
             fail("Handler creation should have thrown a RunTimeException");

--- a/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketServletContextHandlerFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketServletContextHandlerFactoryTest.java
@@ -1,15 +1,14 @@
 package spark.embeddedserver.jetty.websocket;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mockConstructionWithAnswer;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
 import javax.servlet.ServletContext;
-
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -17,114 +16,116 @@ import org.eclipse.jetty.websocket.server.NativeWebSocketConfiguration;
 import org.eclipse.jetty.websocket.server.WebSocketServerFactory;
 import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.stubbing.Answer;
 
-@RunWith(PowerMockRunner.class)
 public class WebSocketServletContextHandlerFactoryTest {
 
     final String webSocketPath = "/websocket";
     private ServletContextHandler servletContextHandler;
 
     @Test
-    public void testCreate_whenWebSocketHandlersIsNull_thenReturnNull() throws Exception {
+    public void testCreate_whenWebSocketHandlersIsNull_thenReturnNull() {
 
         servletContextHandler = WebSocketServletContextHandlerFactory.create(null, Optional.empty());
 
-        assertNull("Should return null because no WebSocket Handlers were passed", servletContextHandler);
+        assertNull(servletContextHandler, "Should return null because no WebSocket Handlers were passed");
 
     }
 
     @Test
-    public void testCreate_whenNoIdleTimeoutIsPresent() throws Exception {
+    public void testCreate_whenNoIdleTimeoutIsPresent() {
 
         Map<String, WebSocketHandlerWrapper> webSocketHandlers = new HashMap<>();
 
         webSocketHandlers.put(webSocketPath, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
 
         servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.empty());
-    
-        ServletContext servletContext = servletContextHandler.getServletContext();
-    
-        WebSocketUpgradeFilter webSocketUpgradeFilter =
-            (WebSocketUpgradeFilter) servletContext.getAttribute("org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter");
 
-        assertNotNull("Should return a WebSocketUpgradeFilter because we configured it to have one", webSocketUpgradeFilter);
-    
-        NativeWebSocketConfiguration webSocketConfiguration =
-            (NativeWebSocketConfiguration) servletContext.getAttribute(NativeWebSocketConfiguration.class.getName());
-        
+        ServletContext servletContext = servletContextHandler.getServletContext();
+
+        WebSocketUpgradeFilter webSocketUpgradeFilter = (WebSocketUpgradeFilter) servletContext
+                .getAttribute("org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter");
+
+        assertNotNull(webSocketUpgradeFilter, "Should return a WebSocketUpgradeFilter because we configured it to have one");
+
+        NativeWebSocketConfiguration webSocketConfiguration = (NativeWebSocketConfiguration) servletContext
+                .getAttribute(NativeWebSocketConfiguration.class.getName());
+
         MappedResource<WebSocketCreator> mappedResource = webSocketConfiguration.getMatch("/websocket");
         PathSpec pathSpec = mappedResource.getPathSpec();
 
-        assertEquals("Should return the WebSocket path specified when context handler was created",
-                webSocketPath, pathSpec.getDeclaration());
-        
-        // Because spark works on a non-initialized / non-started ServletContextHandler and WebSocketUpgradeFilter
-        // the stored WebSocketCreator is wrapped for persistence through the start/stop of those contexts.
+        assertEquals(webSocketPath, pathSpec.getDeclaration(),
+                "Should return the WebSocket path specified when context handler was created");
+
+        // Because spark works on a non-initialized / non-started ServletContextHandler
+        // and WebSocketUpgradeFilter
+        // the stored WebSocketCreator is wrapped for persistence through the start/stop
+        // of those contexts.
         // You cannot unwrap or cast to that WebSocketTestHandler this way.
         // Only websockets that are added during a live context can be cast this way.
         // WebSocketCreator sc = mappedResource.getResource();
-        // assertTrue("Should return true because handler should be an instance of the one we passed when it was created",
-        //        sc.getHandler() instanceof WebSocketTestHandler);
+        // assertTrue("Should return true because handler should be an instance of the
+        // one we passed when it was created",
+        // sc.getHandler() instanceof WebSocketTestHandler);
     }
 
     @Test
-    public void testCreate_whenTimeoutIsPresent() throws Exception {
+    public void testCreate_whenTimeoutIsPresent() {
 
-        final Long timeout = Long.valueOf(1000);
+        final Long timeout = 1000L;
 
         Map<String, WebSocketHandlerWrapper> webSocketHandlers = new HashMap<>();
 
         webSocketHandlers.put(webSocketPath, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
 
         servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.of(timeout));
-    
+
         ServletContext servletContext = servletContextHandler.getServletContext();
 
-        WebSocketUpgradeFilter webSocketUpgradeFilter =
-                (WebSocketUpgradeFilter) servletContext.getAttribute("org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter");
+        WebSocketUpgradeFilter webSocketUpgradeFilter = (WebSocketUpgradeFilter) servletContext
+                .getAttribute("org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter");
 
-        assertNotNull("Should return a WebSocketUpgradeFilter because we configured it to have one", webSocketUpgradeFilter);
-    
-        NativeWebSocketConfiguration webSocketConfiguration =
-            (NativeWebSocketConfiguration) servletContext.getAttribute(NativeWebSocketConfiguration.class.getName());
+        assertNotNull(webSocketUpgradeFilter, "Should return a WebSocketUpgradeFilter because we configured it to have one");
+
+        NativeWebSocketConfiguration webSocketConfiguration = (NativeWebSocketConfiguration) servletContext
+                .getAttribute(NativeWebSocketConfiguration.class.getName());
 
         WebSocketServerFactory webSocketServerFactory = webSocketConfiguration.getFactory();
-        assertEquals("Timeout value should be the same as the timeout specified when context handler was created",
-                timeout.longValue(), webSocketServerFactory.getPolicy().getIdleTimeout());
+        assertEquals(timeout.longValue(), webSocketServerFactory.getPolicy().getIdleTimeout(),
+                "Timeout value should be the same as the timeout specified when context handler was created");
 
         MappedResource<WebSocketCreator> mappedResource = webSocketConfiguration.getMatch("/websocket");
         PathSpec pathSpec = mappedResource.getPathSpec();
 
-        assertEquals("Should return the WebSocket path specified when context handler was created",
-                webSocketPath, pathSpec.getDeclaration());
+        assertEquals(webSocketPath, pathSpec.getDeclaration(),
+                "Should return the WebSocket path specified when context handler was created");
 
-        // Because spark works on a non-initialized / non-started ServletContextHandler and WebSocketUpgradeFilter
-        // the stored WebSocketCreator is wrapped for persistence through the start/stop of those contexts.
+        // Because spark works on a non-initialized / non-started ServletContextHandler
+        // and WebSocketUpgradeFilter
+        // the stored WebSocketCreator is wrapped for persistence through the start/stop
+        // of those contexts.
         // You cannot unwrap or cast to that WebSocketTestHandler this way.
         // Only websockets that are added during a live context can be cast this way.
         // WebSocketCreator sc = mappedResource.getResource();
-        // assertTrue("Should return true because handler should be an instance of the one we passed when it was created",
-        //        sc.getHandler() instanceof WebSocketTestHandler);
+        // assertTrue(sc.getHandler() instanceof WebSocketTestHandler,
+        // "Should return true because handler should be an instance of the one we
+        // passed when it was created",);
     }
 
     @Test
-    @PrepareForTest(WebSocketServletContextHandlerFactory.class)
-    public void testCreate_whenWebSocketContextHandlerCreationFails_thenThrowException() throws Exception {
+    public void testCreate_whenWebSocketContextHandlerCreationFails_thenThrowException() {
+        try (MockedConstruction<ServletContextHandler> ignored = mockConstructionWithAnswer(ServletContextHandler.class, (Answer<RuntimeException>) invocation -> {
+            throw new RuntimeException("Some problem initializing context handler!");
+        })) {
+            Map<String, WebSocketHandlerWrapper> webSocketHandlers = new HashMap<>();
 
-        PowerMockito.whenNew(ServletContextHandler.class).withAnyArguments().thenThrow(new Exception(""));
+            webSocketHandlers.put(webSocketPath, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
 
-        Map<String, WebSocketHandlerWrapper> webSocketHandlers = new HashMap<>();
+            servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.empty());
 
-        webSocketHandlers.put(webSocketPath, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
-
-        servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.empty());
-
-        assertNull("Should return null because Websocket context handler was not created", servletContextHandler);
-
+            assertNull(servletContextHandler, "Should return null because Websocket context handler was not created");
+        }
     }
 }

--- a/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketTestHandler.java
+++ b/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketTestHandler.java
@@ -17,17 +17,17 @@ public class WebSocketTestHandler {
 
     @OnWebSocketConnect
     public void connected(Session session) {
-	events.add("onConnect");
+        events.add("onConnect");
     }
 
     @OnWebSocketClose
     public void closed(int statusCode, String reason) {
-	events.add(String.format("onClose: %s %s", statusCode, reason));
+        events.add(String.format("onClose: %s %s", statusCode, reason));
     }
 
     @OnWebSocketMessage
     public void message(String message) {
-	events.add("onMessage: " + message);
+        events.add("onMessage: " + message);
     }
 
 }

--- a/src/test/java/spark/examples/accept/JsonAcceptTypeExample.java
+++ b/src/test/java/spark/examples/accept/JsonAcceptTypeExample.java
@@ -4,14 +4,11 @@ import static spark.Spark.get;
 
 public class JsonAcceptTypeExample {
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
 
         //Running curl -i -H "Accept: application/json" http://localhost:4567/hello json message is read.
         //Running curl -i -H "Accept: text/html" http://localhost:4567/hello HTTP 404 error is thrown.
-        get("/hello", "application/json", (request, response) -> {
-            return "{\"message\": \"Hello World\"}";
-        });
-
+        get("/hello", "application/json", (request, response) -> "{\"message\": \"Hello World\"}");
     }
 
 }

--- a/src/test/java/spark/examples/books/Book.java
+++ b/src/test/java/spark/examples/books/Book.java
@@ -31,32 +31,20 @@ public class Book {
         this.title = title;
     }
     
-    /**
-     * @return the author
-     */
     public String getAuthor() {
         return author;
     }
 
     
-    /**
-     * @return the title
-     */
     public String getTitle() {
         return title;
     }
     
-    /**
-     * @param author the author to set
-     */
     public void setAuthor(String author) {
         this.author = author;
     }
 
     
-    /**
-     * @param title the title to set
-     */
     public void setTitle(String title) {
         this.title = title;
     }

--- a/src/test/java/spark/examples/books/Books.java
+++ b/src/test/java/spark/examples/books/Books.java
@@ -99,11 +99,11 @@ public class Books {
 
         // Gets all available book resources (id's)
         get("/books", (request, response) -> {
-            String ids = "";
+            StringBuilder ids = new StringBuilder();
             for (String id : books.keySet()) {
-                ids += id + " ";
+                ids.append(id).append(" ");
             }
-            return ids;
+            return ids.toString();
         });
 
     }

--- a/src/test/java/spark/examples/filter/DummyFilter.java
+++ b/src/test/java/spark/examples/filter/DummyFilter.java
@@ -22,19 +22,13 @@ import org.slf4j.LoggerFactory;
 import static spark.Spark.after;
 import static spark.Spark.before;
 
-
 public class DummyFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DummyFilter.class);
 
     public static void main(String[] args) {
-        before((request, response) -> {
-            LOGGER.info("Before");
-        });
+        before((request, response) -> LOGGER.info("Before"));
 
-        after((request, response) -> {
-            LOGGER.info("After");
-        });
+        after((request, response) -> LOGGER.info("After"));
     }
-
 }

--- a/src/test/java/spark/examples/filter/FilterExample.java
+++ b/src/test/java/spark/examples/filter/FilterExample.java
@@ -19,10 +19,6 @@ package spark.examples.filter;
 import java.util.HashMap;
 import java.util.Map;
 
-import spark.Filter;
-import spark.Request;
-import spark.Response;
-
 import static spark.Spark.after;
 import static spark.Spark.before;
 import static spark.Spark.get;
@@ -44,37 +40,28 @@ import static spark.Spark.halt;
  */
 public class FilterExample {
 
-    private static Map<String, String> usernamePasswords = new HashMap<>();
+    private static final Map<String, String> usernamePasswords = new HashMap<>();
 
     public static void main(String[] args) {
 
         usernamePasswords.put("foo", "bar");
         usernamePasswords.put("admin", "admin");
 
-        before(new Filter() {
-            @Override
-            public void handle(Request request, Response response) {
-                String user = request.queryParams("user");
-                String password = request.queryParams("password");
+        before((request, response) -> {
+            String user = request.queryParams("user");
+            String password = request.queryParams("password");
 
-                String dbPassword = usernamePasswords.get(user);
-                if (!(password != null && password.equals(dbPassword))) {
-                    halt(401, "You are not welcome here!!!");
-                }
+            String dbPassword = usernamePasswords.get(user);
+            if (!(password != null && password.equals(dbPassword))) {
+                halt(401, "You are not welcome here!!!");
             }
         });
 
-        before("/hello", (request, response) -> {
-            response.header("Foo", "Set by second before filter");
-        });
+        before("/hello", (request, response) -> response.header("Foo", "Set by second before filter"));
 
-        get("/hello", (request, response) -> {
-            return "Hello World!";
-        });
+        get("/hello", (request, response) -> "Hello World!");
 
-        after("/hello", (request, response) -> {
-            response.header("spark", "added by after-filter");
-        });
+        after("/hello", (request, response) -> response.header("spark", "added by after-filter"));
 
     }
 }

--- a/src/test/java/spark/examples/gzip/GzipClient.java
+++ b/src/test/java/spark/examples/gzip/GzipClient.java
@@ -16,8 +16,7 @@ public class GzipClient {
     public static String getAndDecompress(String url) throws Exception {
         InputStream compressed = get(url);
         GZIPInputStream gzipInputStream = new GZIPInputStream(compressed);
-        String decompressed = IOUtils.toString(gzipInputStream);
-        return decompressed;
+        return IOUtils.toString(gzipInputStream);
     }
 
     public static InputStream get(String url) throws IOException {
@@ -25,7 +24,7 @@ public class GzipClient {
         connection.addRequestProperty("Accept-Encoding", "gzip");
         connection.connect();
 
-        return (InputStream) connection.getInputStream();
+        return connection.getInputStream();
     }
 
 }

--- a/src/test/java/spark/examples/hello/HelloSecureWorld.java
+++ b/src/test/java/spark/examples/hello/HelloSecureWorld.java
@@ -10,9 +10,6 @@ public class HelloSecureWorld {
     public static void main(String[] args) {
 
         secure(args[0], args[1], null, null);
-        get("/hello", (request, response) -> {
-            return "Hello Secure World!";
-        });
-
+        get("/hello", (request, response) -> "Hello Secure World!");
     }
 }

--- a/src/test/java/spark/examples/simple/SimpleSecureExample.java
+++ b/src/test/java/spark/examples/simple/SimpleSecureExample.java
@@ -34,7 +34,7 @@ public class SimpleSecureExample {
     public static void main(String[] args) {
 
         // port(5678); <- Uncomment this if you want spark to listen on a
-        // port different than 4567.
+        // port different from 4567.
 
         secure(
                 SparkTestUtil.getKeyStoreLocation(),

--- a/src/test/java/spark/examples/staticresources/StaticResources.java
+++ b/src/test/java/spark/examples/staticresources/StaticResources.java
@@ -29,8 +29,6 @@ public class StaticResources {
         // Will serve all static file are under "/public" in classpath if the route isn't consumed by others routes.
         staticFiles.location("/public");
 
-        get("/hello", (request, response) -> {
-            return "Hello World!";
-        });
+        get("/hello", (request, response) -> "Hello World!");
     }
 }

--- a/src/test/java/spark/examples/templateview/FreeMarkerExample.java
+++ b/src/test/java/spark/examples/templateview/FreeMarkerExample.java
@@ -8,7 +8,7 @@ import static spark.Spark.modelAndView;
 
 public class FreeMarkerExample {
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
 
         get("/hello", (request, response) -> {
             Map<String, Object> attributes = new HashMap<>();

--- a/src/test/java/spark/examples/templateview/FreeMarkerTemplateEngine.java
+++ b/src/test/java/spark/examples/templateview/FreeMarkerTemplateEngine.java
@@ -11,7 +11,7 @@ import spark.TemplateEngine;
 
 public class FreeMarkerTemplateEngine extends TemplateEngine {
 
-    private Configuration configuration;
+    private final Configuration configuration;
 
     protected FreeMarkerTemplateEngine() {
         this.configuration = createFreemarkerConfiguration();
@@ -26,9 +26,7 @@ public class FreeMarkerTemplateEngine extends TemplateEngine {
             template.process(modelAndView.getModel(), stringWriter);
 
             return stringWriter.toString();
-        } catch (IOException e) {
-            throw new IllegalArgumentException(e);
-        } catch (TemplateException e) {
+        } catch (IOException | TemplateException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/src/test/java/spark/examples/transformer/DefaultTransformerExample.java
+++ b/src/test/java/spark/examples/transformer/DefaultTransformerExample.java
@@ -7,17 +7,13 @@ import static spark.Spark.defaultResponseTransformer;
 
 public class DefaultTransformerExample {
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
 
         defaultResponseTransformer(json);
 
-        get("/hello", "application/json", (request, response) -> {
-            return new MyMessage("Hello World");
-        });
+        get("/hello", "application/json", (request, response) -> new MyMessage("Hello World"));
 
-        get("/hello2", "application/json", (request, response) -> {
-            return new MyMessage("Hello World");
-        }, model -> "custom transformer");
+        get("/hello2", "application/json", (request, response) -> new MyMessage("Hello World"), model -> "custom transformer");
     }
 
     private static final ResponseTransformer json = new JsonTransformer();

--- a/src/test/java/spark/examples/transformer/JsonTransformer.java
+++ b/src/test/java/spark/examples/transformer/JsonTransformer.java
@@ -6,7 +6,7 @@ import com.google.gson.Gson;
 
 public class JsonTransformer implements ResponseTransformer {
 
-	private Gson gson = new Gson();
+	private final Gson gson = new Gson();
 
 	@Override
 	public String render(Object model) {

--- a/src/test/java/spark/examples/transformer/TransformerExample.java
+++ b/src/test/java/spark/examples/transformer/TransformerExample.java
@@ -4,10 +4,8 @@ import static spark.Spark.get;
 
 public class TransformerExample {
 
-    public static void main(String args[]) {
-        get("/hello", "application/json", (request, response) -> {
-            return new MyMessage("Hello World");
-        }, new JsonTransformer());
+    public static void main(String[] args) {
+        get("/hello", "application/json", (request, response) -> new MyMessage("Hello World"), new JsonTransformer());
     }
 
 }

--- a/src/test/java/spark/globalstate/ServletFlagTest.java
+++ b/src/test/java/spark/globalstate/ServletFlagTest.java
@@ -1,52 +1,49 @@
 package spark.globalstate;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-@RunWith(PowerMockRunner.class)
 public class ServletFlagTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
 
         Whitebox.setInternalState(ServletFlag.class, "isRunningFromServlet", new AtomicBoolean(false));
     }
 
     @Test
-    public void testRunFromServlet_whenDefault() throws Exception {
+    public void testRunFromServlet_whenDefault() {
 
         AtomicBoolean isRunningFromServlet = Whitebox.getInternalState(ServletFlag.class, "isRunningFromServlet");
-        assertFalse("Should be false because it is the default value", isRunningFromServlet.get());
+        assertFalse(isRunningFromServlet.get(), "Should be false because it is the default value");
     }
 
     @Test
-    public void testRunFromServlet_whenExecuted() throws Exception {
+    public void testRunFromServlet_whenExecuted() {
 
         ServletFlag.runFromServlet();
         AtomicBoolean isRunningFromServlet = Whitebox.getInternalState(ServletFlag.class, "isRunningFromServlet");
 
-        assertTrue("Should be true because it flag has been set after runFromServlet", isRunningFromServlet.get());
+        assertTrue(isRunningFromServlet.get(), "Should be true because it flag has been set after runFromServlet");
     }
 
     @Test
-    public void testIsRunningFromServlet_whenDefault() throws Exception {
+    public void testIsRunningFromServlet_whenDefault() {
 
-        assertFalse("Should be false because it is the default value", ServletFlag.isRunningFromServlet());
+        assertFalse(ServletFlag.isRunningFromServlet(), "Should be false because it is the default value");
 
     }
 
     @Test
-    public void testIsRunningFromServlet_whenRunningFromServlet() throws Exception {
+    public void testIsRunningFromServlet_whenRunningFromServlet() {
 
         ServletFlag.runFromServlet();
-        assertTrue("Should be true because call to runFromServlet has been made", ServletFlag.isRunningFromServlet());
+        assertTrue(ServletFlag.isRunningFromServlet(), "Should be true because call to runFromServlet has been made");
     }
 }

--- a/src/test/java/spark/resource/UriPathTest.java
+++ b/src/test/java/spark/resource/UriPathTest.java
@@ -1,12 +1,12 @@
 package spark.resource;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class UriPathTest {
     @Test
-    public void canonical() throws Exception {
+    public void canonical() {
         String[][] canonical = {
             {"/aaa/bbb/", "/aaa/bbb/"},
             {"/aaa//bbb/", "/aaa//bbb/"},
@@ -57,7 +57,7 @@ public class UriPathTest {
         };
 
         for (String[] aCanonical : canonical) {
-            assertEquals("canonical " + aCanonical[0], aCanonical[1], UriPath.canonical(aCanonical[0]));
+            assertEquals(aCanonical[1], UriPath.canonical(aCanonical[0]), "canonical " + aCanonical[0]);
         }
     }
 

--- a/src/test/java/spark/route/HttpMethodTest.java
+++ b/src/test/java/spark/route/HttpMethodTest.java
@@ -16,8 +16,9 @@
  */
 package spark.route;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the HttpMethod.
@@ -29,14 +30,14 @@ public class HttpMethodTest {
         HttpMethod get = HttpMethod.get;
         HttpMethod method = HttpMethod.get(get.name());
 
-        Assert.assertEquals(get, method);
+        assertEquals(get, method);
     }
 
     @Test
     public void testNotSupportedHttpMethod() {
         HttpMethod method = HttpMethod.get("lock");
 
-        Assert.assertEquals(HttpMethod.unsupported, method);
+        assertEquals(HttpMethod.unsupported, method);
     }
 
 }

--- a/src/test/java/spark/route/RouteEntryTest.java
+++ b/src/test/java/spark/route/RouteEntryTest.java
@@ -1,11 +1,10 @@
 package spark.route;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Test;
 import spark.utils.SparkUtils;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class RouteEntryTest {
 
@@ -16,11 +15,8 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.before;
         entry.path = SparkUtils.ALL_PATHS;
 
-        assertTrue(
-                "Should return true because HTTP method is \"Before\", the methods of route and match request match," +
-                        " and the path provided is same as ALL_PATHS (+/*paths)",
-                entry.matches(HttpMethod.before, SparkUtils.ALL_PATHS)
-        );
+        assertTrue(entry.matches(HttpMethod.before, SparkUtils.ALL_PATHS), "Should return true because HTTP method is \"Before\", "
+                + "the methods of route and match request match, and the path provided is same as ALL_PATHS (+/*paths)");
     }
 
     @Test
@@ -30,11 +26,8 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.after;
         entry.path = SparkUtils.ALL_PATHS;
 
-        assertTrue(
-                "Should return true because HTTP method is \"After\", the methods of route and match request match," +
-                        " and the path provided is same as ALL_PATHS (+/*paths)",
-                entry.matches(HttpMethod.after, SparkUtils.ALL_PATHS)
-        );
+        assertTrue(entry.matches(HttpMethod.after, SparkUtils.ALL_PATHS), "Should return true because HTTP method is \"After\", "
+                + "the methods of route and match request match, and the path provided is same as ALL_PATHS (+/*paths)");
     }
 
     @Test
@@ -44,8 +37,7 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.post;
         entry.path = "/test";
 
-        assertFalse("Should return false because path names did not match",
-                    entry.matches(HttpMethod.get, "/path"));
+        assertFalse(entry.matches(HttpMethod.get, "/path"), "Should return false because path names did not match");
     }
 
     @Test
@@ -55,10 +47,8 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.get;
         entry.path = "/test";
 
-        assertFalse("Should return false because route path does not end with a slash, does not end with " +
-                            "a wildcard, and the route pah supplied ends with a slash ",
-                    entry.matches(HttpMethod.get, "/test/")
-        );
+        assertFalse(entry.matches(HttpMethod.get, "/test/"), "Should return false because route path does not end with a slash, "
+                + "does not end with a wildcard, and the route pah supplied ends with a slash");
     }
 
     @Test
@@ -68,8 +58,8 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.get;
         entry.path = "/test/";
 
-        assertFalse("Should return false because route path ends with a slash while path supplied as parameter does" +
-                            "not end with a slash", entry.matches(HttpMethod.get, "/test"));
+        assertFalse(entry.matches(HttpMethod.get, "/test"), "Should return false because route path ends with a slash while "
+                + "path supplied as parameter does not end with a slash");
     }
 
     @Test
@@ -79,8 +69,7 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.get;
         entry.path = "/test/";
 
-        assertTrue("Should return true because route path and path is exactly the same",
-                   entry.matches(HttpMethod.get, "/test/"));
+        assertTrue(entry.matches(HttpMethod.get, "/test/"), "Should return true because route path and path is exactly the same");
     }
 
     @Test
@@ -90,8 +79,8 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.get;
         entry.path = "/test/*";
 
-        assertTrue("Should return true because path specified is covered by the route path wildcard",
-                   entry.matches(HttpMethod.get, "/test/me"));
+        assertTrue(entry.matches(HttpMethod.get, "/test/me"), 
+                "Should return true because path specified is covered by the route path wildcard");
     }
 
     @Test
@@ -101,8 +90,7 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.get;
         entry.path = "/test/me";
 
-        assertFalse("Should return false because path does not match route path",
-                    entry.matches(HttpMethod.get, "/test/other"));
+        assertFalse(entry.matches(HttpMethod.get, "/test/other"), "Should return false because path does not match route path");
     }
 
     @Test
@@ -112,8 +100,8 @@ public class RouteEntryTest {
         entry.httpMethod = HttpMethod.get;
         entry.path = "/test/this/resource/*";
 
-        assertTrue("Should return true because path specified is covered by the route path wildcard",
-                   entry.matches(HttpMethod.get, "/test/this/resource/child/id"));
+        assertTrue(entry.matches(HttpMethod.get, "/test/this/resource/child/id"), 
+                "Should return true because path specified is covered by the route path wildcard");
     }
 
 }

--- a/src/test/java/spark/serialization/InputStreamSerializerTest.java
+++ b/src/test/java/spark/serialization/InputStreamSerializerTest.java
@@ -1,13 +1,14 @@
 package spark.serialization;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.*;
+import org.junit.jupiter.api.Test;
 
 public class InputStreamSerializerTest {
 
-    private InputStreamSerializer serializer = new InputStreamSerializer();
+    private final InputStreamSerializer serializer = new InputStreamSerializer();
 
     @Test
     public void testProcess_copiesData() throws IOException {
@@ -17,7 +18,7 @@ public class InputStreamSerializerTest {
 
         serializer.process(output, input);
 
-        Assert.assertArrayEquals(bytes, output.toByteArray());
+        assertArrayEquals(bytes, output.toByteArray());
     }
 
     @Test
@@ -27,10 +28,10 @@ public class InputStreamSerializerTest {
 
         serializer.process(output, input);
 
-        Assert.assertTrue("Expected stream to be closed", input.closed);
+        assertTrue(input.closed, "Expected stream to be closed");
     }
 
-    private class MockInputStream extends FilterInputStream {
+    private static class MockInputStream extends FilterInputStream {
 
         boolean closed = false;
 

--- a/src/test/java/spark/servlet/FilterConfigWrapper.java
+++ b/src/test/java/spark/servlet/FilterConfigWrapper.java
@@ -5,28 +5,20 @@ import java.util.Enumeration;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 
-
 public class FilterConfigWrapper implements FilterConfig {
  
-    private FilterConfig delegate;
+    private final FilterConfig delegate;
 
     public FilterConfigWrapper(FilterConfig delegate) {
         this.delegate = delegate;
     }
-    
-    /**
-     * @return
-     * @see javax.servlet.FilterConfig#getFilterName()
-     */
+
+    @Override
     public String getFilterName() {
         return delegate.getFilterName();
     }
 
-    /**
-     * @param name
-     * @return
-     * @see javax.servlet.FilterConfig#getInitParameter(java.lang.String)
-     */
+    @Override
     public String getInitParameter(String name) {
         if (name.equals("applicationClass")) {
             return "spark.servlet.MyApp";
@@ -34,20 +26,13 @@ public class FilterConfigWrapper implements FilterConfig {
         return delegate.getInitParameter(name);
     }
 
-    /**
-     * @return
-     * @see javax.servlet.FilterConfig#getInitParameterNames()
-     */
+    @Override
     public Enumeration<String> getInitParameterNames() {
         return delegate.getInitParameterNames();
     }
 
-    /**
-     * @return
-     * @see javax.servlet.FilterConfig#getServletContext()
-     */
+    @Override
     public ServletContext getServletContext() {
         return delegate.getServletContext();
     }
-    
 }

--- a/src/test/java/spark/servlet/MyApp.java
+++ b/src/test/java/spark/servlet/MyApp.java
@@ -32,21 +32,13 @@ public class MyApp implements SparkApplication {
             e.printStackTrace();
         }
 
-        before("/protected/*", (request, response) -> {
-            halt(401, "Go Away!");
-        });
+        before("/protected/*", (request, response) -> halt(401, "Go Away!"));
 
-        get("/hi", (request, response) -> {
-            return "Hello World!";
-        });
+        get("/hi", (request, response) -> "Hello World!");
 
-        get("/:param", (request, response) -> {
-            return "echo: " + request.params(":param");
-        });
+        get("/:param", (request, response) -> "echo: " + request.params(":param"));
 
-        get("/", (request, response) -> {
-            return "Hello Root!";
-        });
+        get("/", (request, response) -> "Hello Root!");
 
         post("/poster", (request, response) -> {
             String body = request.body();
@@ -54,14 +46,11 @@ public class MyApp implements SparkApplication {
             return "Body was: " + body;
         });
 
-        after("/hi", (request, response) -> {
-            response.header("after", "foobar");
-        });
+        after("/hi", (request, response) -> response.header("after", "foobar"));
 
         try {
             Thread.sleep(500);
-        } catch (Exception e) {
+        } catch (Exception ignored) {
         }
     }
-
 }

--- a/src/test/java/spark/staticfiles/DisableMimeGuessingTest.java
+++ b/src/test/java/spark/staticfiles/DisableMimeGuessingTest.java
@@ -19,11 +19,9 @@ package spark.staticfiles;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +29,7 @@ import spark.Spark;
 import spark.examples.exception.NotFoundException;
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static spark.Spark.get;
 import static spark.Spark.staticFiles;
 
@@ -49,7 +48,7 @@ public class DisableMimeGuessingTest {
 
     private static File tmpExternalFile;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
         if (tmpExternalFile != null) {
@@ -58,7 +57,7 @@ public class DisableMimeGuessingTest {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -84,20 +83,20 @@ public class DisableMimeGuessingTest {
 
     @Test
     public void testMimeTypes() throws Exception {
-        Assert.assertNull(doGet("/pages/index.html").headers.get("Content-Type"));
-        Assert.assertNull(doGet("/js/scripts.js").headers.get("Content-Type"));
-        Assert.assertNull(doGet("/css/style.css").headers.get("Content-Type"));
-        Assert.assertNull(doGet("/img/sparklogo.png").headers.get("Content-Type"));
-        Assert.assertNull(doGet("/img/sparklogo.svg").headers.get("Content-Type"));
-        Assert.assertNull(doGet("/img/sparklogoPng").headers.get("Content-Type"));
-        Assert.assertNull(doGet("/img/sparklogoSvg").headers.get("Content-Type"));
-        Assert.assertNull(doGet("/externalFile.html").headers.get("Content-Type"));
+        assertNull(doGet("/pages/index.html").headers.get("Content-Type"));
+        assertNull(doGet("/js/scripts.js").headers.get("Content-Type"));
+        assertNull(doGet("/css/style.css").headers.get("Content-Type"));
+        assertNull(doGet("/img/sparklogo.png").headers.get("Content-Type"));
+        assertNull(doGet("/img/sparklogo.svg").headers.get("Content-Type"));
+        assertNull(doGet("/img/sparklogoPng").headers.get("Content-Type"));
+        assertNull(doGet("/img/sparklogoSvg").headers.get("Content-Type"));
+        assertNull(doGet("/externalFile.html").headers.get("Content-Type"));
     }
 
     @Test
     public void testCustomMimeType() throws Exception {
         staticFiles.registerMimeType("cxt", "custom-extension-type");
-        Assert.assertNull(doGet("/img/file.cxt").headers.get("Content-Type"));
+        assertNull(doGet("/img/file.cxt").headers.get("Content-Type"));
     }
 
     private SparkTestUtil.UrlResponse doGet(String fileName) throws Exception {

--- a/src/test/java/spark/staticfiles/StaticFilesTest.java
+++ b/src/test/java/spark/staticfiles/StaticFilesTest.java
@@ -20,11 +20,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URLEncoder;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +30,8 @@ import spark.Spark;
 import spark.examples.exception.NotFoundException;
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.exception;
 import static spark.Spark.get;
 import static spark.Spark.staticFiles;
@@ -54,7 +54,7 @@ public class StaticFilesTest {
 
     private static File tmpExternalFile;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
         if (tmpExternalFile != null) {
@@ -63,7 +63,7 @@ public class StaticFilesTest {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -93,28 +93,28 @@ public class StaticFilesTest {
 
     @Test
     public void testMimeTypes() throws Exception {
-        Assert.assertEquals("text/html", doGet("/pages/index.html").headers.get("Content-Type"));
-        Assert.assertEquals("application/javascript", doGet("/js/scripts.js").headers.get("Content-Type"));
-        Assert.assertEquals("text/css", doGet("/css/style.css").headers.get("Content-Type"));
-        Assert.assertEquals("image/png", doGet("/img/sparklogo.png").headers.get("Content-Type"));
-        Assert.assertEquals("image/svg+xml", doGet("/img/sparklogo.svg").headers.get("Content-Type"));
-        Assert.assertEquals("application/octet-stream", doGet("/img/sparklogoPng").headers.get("Content-Type"));
-        Assert.assertEquals("application/octet-stream", doGet("/img/sparklogoSvg").headers.get("Content-Type"));
-        Assert.assertEquals("text/html", doGet("/externalFile.html").headers.get("Content-Type"));
+        assertEquals("text/html", doGet("/pages/index.html").headers.get("Content-Type"));
+        assertEquals("application/javascript", doGet("/js/scripts.js").headers.get("Content-Type"));
+        assertEquals("text/css", doGet("/css/style.css").headers.get("Content-Type"));
+        assertEquals("image/png", doGet("/img/sparklogo.png").headers.get("Content-Type"));
+        assertEquals("image/svg+xml", doGet("/img/sparklogo.svg").headers.get("Content-Type"));
+        assertEquals("application/octet-stream", doGet("/img/sparklogoPng").headers.get("Content-Type"));
+        assertEquals("application/octet-stream", doGet("/img/sparklogoSvg").headers.get("Content-Type"));
+        assertEquals("text/html", doGet("/externalFile.html").headers.get("Content-Type"));
     }
 
     @Test
     public void testCustomMimeType() throws Exception {
         staticFiles.registerMimeType("cxt", "custom-extension-type");
-        Assert.assertEquals("custom-extension-type", doGet("/img/file.cxt").headers.get("Content-Type"));
+        assertEquals("custom-extension-type", doGet("/img/file.cxt").headers.get("Content-Type"));
     }
 
     @Test
     public void testStaticFileCssStyleCss() throws Exception {
         SparkTestUtil.UrlResponse response = doGet("/css/style.css");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("text/css", response.headers.get("Content-Type"));
-        Assert.assertEquals("Content of css file", response.body);
+        assertEquals(200, response.status);
+        assertEquals("text/css", response.headers.get("Content-Type"));
+        assertEquals("Content of css file", response.body);
 
         testGet();
     }
@@ -122,8 +122,8 @@ public class StaticFilesTest {
     @Test
     public void testStaticFilePagesIndexHtml() throws Exception {
         SparkTestUtil.UrlResponse response = doGet("/pages/index.html");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("<html><body>Hello Static World!</body></html>", response.body);
+        assertEquals(200, response.status);
+        assertEquals("<html><body>Hello Static World!</body></html>", response.body);
 
         testGet();
     }
@@ -131,8 +131,8 @@ public class StaticFilesTest {
     @Test
     public void testStaticFilePageHtml() throws Exception {
         SparkTestUtil.UrlResponse response = doGet("/page.html");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("<html><body>Hello Static Files World!</body></html>", response.body);
+        assertEquals(200, response.status);
+        assertEquals("<html><body>Hello Static Files World!</body></html>", response.body);
 
         testGet();
     }
@@ -142,7 +142,7 @@ public class StaticFilesTest {
         String path = "/" + URLEncoder.encode("..\\spark\\", "UTF-8") + "Spark.class";
         SparkTestUtil.UrlResponse response = doGet(path);
 
-        Assert.assertEquals(400, response.status);
+        assertEquals(400, response.status);
 
         testGet();
     }
@@ -150,8 +150,8 @@ public class StaticFilesTest {
     @Test
     public void testExternalStaticFile() throws Exception {
         SparkTestUtil.UrlResponse response = doGet("/externalFile.html");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals(CONTENT_OF_EXTERNAL_FILE, response.body);
+        assertEquals(200, response.status);
+        assertEquals(CONTENT_OF_EXTERNAL_FILE, response.body);
 
         testGet();
     }
@@ -162,16 +162,16 @@ public class StaticFilesTest {
     private static void testGet() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hello", "");
 
-        Assert.assertEquals(200, response.status);
-        Assert.assertTrue(response.body.contains(FO_SHIZZY));
+        assertEquals(200, response.status);
+        assertTrue(response.body.contains(FO_SHIZZY));
     }
 
     @Test
     public void testExceptionMapping404() throws Exception {
         SparkTestUtil.UrlResponse response = doGet("/filethatdoesntexist.html");
 
-        Assert.assertEquals(404, response.status);
-        Assert.assertEquals(NOT_FOUND_BRO, response.body);
+        assertEquals(404, response.status);
+        assertEquals(NOT_FOUND_BRO, response.body);
     }
 
     private SparkTestUtil.UrlResponse doGet(String fileName) throws Exception {

--- a/src/test/java/spark/staticfiles/StaticFilesTestExternal.java
+++ b/src/test/java/spark/staticfiles/StaticFilesTestExternal.java
@@ -20,11 +20,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URLEncoder;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +30,8 @@ import spark.Spark;
 import spark.examples.exception.NotFoundException;
 import spark.util.SparkTestUtil;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spark.Spark.exception;
 import static spark.Spark.get;
 import static spark.Spark.staticFiles;
@@ -56,7 +56,7 @@ public class StaticFilesTestExternal {
     private static File tmpExternalFile2;
     private static File folderOutsideStaticFiles;
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Spark.stop();
         if (tmpExternalFile1 != null) {
@@ -67,7 +67,7 @@ public class StaticFilesTestExternal {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         testUtil = new SparkTestUtil(4567);
 
@@ -109,9 +109,9 @@ public class StaticFilesTestExternal {
     @Test
     public void testExternalStaticFile() throws Exception {
         SparkTestUtil.UrlResponse response = doGet("/externalFile.html");
-        Assert.assertEquals(200, response.status);
-        Assert.assertEquals("text/html", response.headers.get("Content-Type"));
-        Assert.assertEquals(CONTENT_OF_EXTERNAL_FILE, response.body);
+        assertEquals(200, response.status);
+        assertEquals("text/html", response.headers.get("Content-Type"));
+        assertEquals(CONTENT_OF_EXTERNAL_FILE, response.body);
 
         testGet();
     }
@@ -121,8 +121,8 @@ public class StaticFilesTestExternal {
         String path = "/" + URLEncoder.encode("..\\..\\spark\\", "UTF-8") + "Spark.class";
         SparkTestUtil.UrlResponse response = doGet(path);
 
-        Assert.assertEquals(404, response.status);
-        Assert.assertEquals(NOT_FOUND_BRO, response.body);
+        assertEquals(404, response.status);
+        assertEquals(NOT_FOUND_BRO, response.body);
 
         testGet();
     }
@@ -130,8 +130,8 @@ public class StaticFilesTestExternal {
     private static void testGet() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hello", "");
 
-        Assert.assertEquals(200, response.status);
-        Assert.assertTrue(response.body.contains(FO_SHIZZY));
+        assertEquals(200, response.status);
+        assertTrue(response.body.contains(FO_SHIZZY));
     }
 
     private SparkTestUtil.UrlResponse doGet(String fileName) throws Exception {

--- a/src/test/java/spark/util/ResourceUtilsTest.java
+++ b/src/test/java/spark/util/ResourceUtilsTest.java
@@ -1,34 +1,24 @@
 package spark.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
+import org.junit.jupiter.api.Test;
 import spark.utils.ResourceUtils;
-
-import static org.junit.Assert.assertEquals;
 
 public class ResourceUtilsTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
-    public void testGetFile_whenURLProtocolIsNotFile_thenThrowFileNotFoundException() throws
-                                                                                      MalformedURLException,
-                                                                                      FileNotFoundException {
-        thrown.expect(FileNotFoundException.class);
-        thrown.expectMessage("My File Path cannot be resolved to absolute file path " +
-                                     "because it does not reside in the file system: http://example.com/");
-
+    public void testGetFile_whenURLProtocolIsNotFile_thenThrowFileNotFoundException() throws MalformedURLException {
         URL url = new URL("http://example.com/");
-        ResourceUtils.getFile(url, "My File Path");
+        final FileNotFoundException ex = assertThrows(FileNotFoundException.class, () -> ResourceUtils.getFile(url, "My File Path"));
+        assertEquals("My File Path cannot be resolved to absolute file path " +
+              "because it does not reside in the file system: http://example.com/", ex.getMessage());
     }
 
     @Test
@@ -36,12 +26,10 @@ public class ResourceUtilsTest {
                                                                          MalformedURLException,
                                                                          FileNotFoundException,
                                                                          URISyntaxException {
-        //given
         URL url = new URL("file://public/file.txt");
         File file = ResourceUtils.getFile(url, "Some description");
 
-        //then
-        assertEquals("Should be equals because URL protocol is file", file, new File(ResourceUtils.toURI(url).getSchemeSpecificPart()));
+        assertEquals(file, new File(ResourceUtils.toURI(url).getSchemeSpecificPart()), "Should be equals because URL protocol is file");
     }
 
 }

--- a/src/test/java/spark/util/SparkTestUtil.java
+++ b/src/test/java/spark/util/SparkTestUtil.java
@@ -43,7 +43,7 @@ import org.apache.http.util.EntityUtils;
 
 public class SparkTestUtil {
 
-    private int port;
+    private final int port;
 
     private HttpClient httpClient;
 
@@ -67,6 +67,7 @@ public class SparkTestUtil {
     public void setFollowRedirectStrategy(Integer... codes) {
         final List<Integer> redirectCodes = Arrays.asList(codes);
         DefaultRedirectStrategy redirectStrategy = new DefaultRedirectStrategy() {
+            @Override
             public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context) {
                 boolean isRedirect = false;
                 try {
@@ -238,7 +239,7 @@ public class SparkTestUtil {
      * keystore specified in JVM params
      */
     private SSLSocketFactory getSslFactory() {
-        KeyStore keyStore = null;
+        KeyStore keyStore;
         try {
             keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             FileInputStream fis = new FileInputStream(getTrustStoreLocation());
@@ -309,7 +310,7 @@ public class SparkTestUtil {
     public static void sleep(long time) {
         try {
             Thread.sleep(time);
-        } catch (Exception e) {
+        } catch (Exception ignored) {
         }
     }
 

--- a/src/test/java/spark/utils/CollectionUtilsTest.java
+++ b/src/test/java/spark/utils/CollectionUtilsTest.java
@@ -1,11 +1,11 @@
 package spark.utils;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 public class CollectionUtilsTest {
 
@@ -14,7 +14,7 @@ public class CollectionUtilsTest {
 
         Collection<Object> testCollection = new ArrayList<>();
 
-        assertTrue("Should return true because collection is empty", CollectionUtils.isEmpty(testCollection));
+        assertTrue(CollectionUtils.isEmpty(testCollection), "Should return true because collection is empty");
 
     }
 
@@ -25,7 +25,7 @@ public class CollectionUtilsTest {
         testCollection.add(1);
         testCollection.add(2);
 
-        assertFalse("Should return false because collection is not empty", CollectionUtils.isEmpty(testCollection));
+        assertFalse(CollectionUtils.isEmpty(testCollection), "Should return false because collection is not empty");
 
     }
 
@@ -34,7 +34,7 @@ public class CollectionUtilsTest {
 
         Collection<Integer> testCollection = null;
 
-        assertTrue("Should return true because collection is null", CollectionUtils.isEmpty(testCollection));
+        assertTrue(CollectionUtils.isEmpty(testCollection), "Should return true because collection is null");
 
     }
 
@@ -43,7 +43,7 @@ public class CollectionUtilsTest {
 
         Collection<Object> testCollection = new ArrayList<>();
 
-        assertFalse("Should return false because collection is empty", CollectionUtils.isNotEmpty(testCollection));
+        assertFalse(CollectionUtils.isNotEmpty(testCollection), "Should return false because collection is empty");
 
     }
 
@@ -54,7 +54,7 @@ public class CollectionUtilsTest {
         testCollection.add(1);
         testCollection.add(2);
 
-        assertTrue("Should return true because collection is not empty", CollectionUtils.isNotEmpty(testCollection));
+        assertTrue(CollectionUtils.isNotEmpty(testCollection), "Should return true because collection is not empty");
 
     }
 
@@ -63,7 +63,7 @@ public class CollectionUtilsTest {
 
         Collection<Object> testCollection = null;
 
-        assertFalse("Should return false because collection is null", CollectionUtils.isNotEmpty(testCollection));
+        assertFalse(CollectionUtils.isNotEmpty(testCollection), "Should return false because collection is null");
 
     }
 }

--- a/src/test/java/spark/utils/MimeParseTest.java
+++ b/src/test/java/spark/utils/MimeParseTest.java
@@ -1,38 +1,38 @@
 package spark.utils;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 public class MimeParseTest {
 
     @Test
-    public void testBestMatch() throws Exception {
+    public void testBestMatch() {
 
         final String header = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
 
         Collection<String> supported = Arrays.asList("application/xml", "text/html");
 
-        assertEquals("bestMatch should return the supported mime type with the highest quality factor" +
-                        "because it is preferred mime type as indicated in the HTTP header",
-                "text/html", MimeParse.bestMatch(supported, header));
+        assertEquals("text/html", MimeParse.bestMatch(supported, header), 
+                "bestMatch should return the supported mime type with the highest quality factor "
+                + "because it is preferred mime type as indicated in the HTTP header");
 
     }
 
     @Test
-    public void testBestMatch_whenSupportedIsLowQualityFactor() throws Exception {
+    public void testBestMatch_whenSupportedIsLowQualityFactor() {
 
         final String header = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
 
-        Collection<String> supported = Arrays.asList("application/json");
+        Collection<String> supported = Collections.singletonList("application/json");
 
-        assertEquals("bestMatch should return the mime type even if it is not included in the supported" +
-                        "mime types because it is considered by the */* all media type specified in the Accept" +
-                        "Header",
-                "application/json", MimeParse.bestMatch(supported, header));
+        assertEquals("application/json", MimeParse.bestMatch(supported, header),
+                "bestMatch should return the mime type even if it is not included in the supported " +
+                        "mime types because it is considered by the */* all media type specified in the Accept Header");
 
     }
 

--- a/src/test/java/spark/utils/ObjectUtilsTest.java
+++ b/src/test/java/spark/utils/ObjectUtilsTest.java
@@ -1,22 +1,19 @@
 package spark.utils;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 public class ObjectUtilsTest {
 
     @Test
-    public void testIsEmpty_whenArrayIsEmpty() throws Exception {
-
-        assertTrue("Should return false because array is empty", ObjectUtils.isEmpty(new Object[]{}));
-
+    public void testIsEmpty_whenArrayIsEmpty() {
+        assertTrue(ObjectUtils.isEmpty(new Object[]{}), "Should return true because array is empty");
     }
 
     @Test
-    public void testIsEmpty_whenArrayIsNotEmpty() throws Exception {
-
-        assertFalse("Should return false because array is not empty", ObjectUtils.isEmpty(new Integer[]{1,2}));
-
+    public void testIsEmpty_whenArrayIsNotEmpty() {
+        assertFalse(ObjectUtils.isEmpty(new Integer[]{1,2}), "Should return false because array is not empty");
     }
 }

--- a/src/test/java/spark/utils/SparkUtilsTest.java
+++ b/src/test/java/spark/utils/SparkUtilsTest.java
@@ -1,17 +1,18 @@
 package spark.utils;
 
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SparkUtilsTest {
 
     @Test
-    public void testConvertRouteToList() throws Exception {
+    public void testConvertRouteToList() {
 
         List<String> expected = Arrays.asList("api", "person", ":id");
 
@@ -20,37 +21,26 @@ public class SparkUtilsTest {
         assertThat("Should return route as a list of individual elements that path is made of",
                 actual,
                 is(expected));
-
     }
 
     @Test
-    public void testIsParam_whenParameterFormattedAsParm() throws Exception {
-
-        assertTrue("Should return true because parameter follows convention of a parameter (:paramname)",
-                SparkUtils.isParam(":param"));
-
+    public void testIsParam_whenParameterFormattedAsParam() {
+        assertTrue(SparkUtils.isParam(":param"), "Should return true because parameter follows convention of a parameter (:paramname)");
     }
 
     @Test
-    public void testIsParam_whenParameterNotFormattedAsParm() throws Exception {
-
-        assertFalse("Should return false because parameter does not follows convention of a parameter (:paramname)",
-                SparkUtils.isParam(".param"));
-
+    public void testIsParam_whenParameterNotFormattedAsParam() {
+        assertFalse(SparkUtils.isParam(".param"), "Should return false because parameter does not follows convention of a parameter (:paramname)");
     }
 
 
     @Test
-    public void testIsSplat_whenParameterIsASplat() throws Exception {
-
-        assertTrue("Should return true because parameter is a splat (*)", SparkUtils.isSplat("*"));
-
+    public void testIsSplat_whenParameterIsASplat() {
+        assertTrue(SparkUtils.isSplat("*"), "Should return true because parameter is a splat (*)");
     }
 
     @Test
-    public void testIsSplat_whenParameterIsNotASplat() throws Exception {
-
-        assertFalse("Should return true because parameter is not a splat (*)", SparkUtils.isSplat("!"));
-
+    public void testIsSplat_whenParameterIsNotASplat() {
+        assertFalse(SparkUtils.isSplat("!"), "Should return false because parameter is not a splat (*)");
     }
 }


### PR DESCRIPTION
Upgraded JUnit from 4.13.2 to 5.8.2
Upgraded Mockito from 1.10.19 to 4.4.0

Reduced the usage of PowerMock (updated from 1.7.4 to 2.0.9) to Whitebox
class, more code must be refactored to avoid such practices.

Replaced legacy JUnit 4 API with modern JUnit 5 API.

Statically importing usages of assertXXX method to reduce boilerplate
code.

Replaced @Test(expected = ...) with new functional API
assertThrows(...).
Replaced some bad usages of assertTrue/False(actual = expected) with
assert[Not]Equals(expected, actual).
Fixed minor typos in some assertXXX messages.
Improved usage of functional syntax whenever possible.
Finalized variables in tests.
Removed unthrown exceptions.
Catching all CVSS medium (4) and onwards vulnerabilities.