### PR TITLE
Updating Spark to Java 11 and Jetty 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 [![](https://img.shields.io/github/license/perwendel/spark.svg)](./LICENSE)
 [![](https://img.shields.io/maven-central/v/com.sparkjava/spark-core.svg)](http://mvnrepository.com/artifact/com.sparkjava/spark-core)
 
-Spark - a tiny web framework for Java 8
+Spark - a tiny web framework for Java 11
 ==============================================
 
-**Spark 2.9.3 is out!!**  <a href="https://github.com/perwendel/spark/blob/master/changeset/2.9.3-changeset.md">Changeset</a> 
+**Spark 3.0.0 is out!!**  <a href="https://github.com/perwendel/spark/blob/master/changeset/3.0.0-changeset.md">Changeset</a> 
 ```xml
 <dependency>
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
-    <version>2.9.3</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 
@@ -31,7 +31,7 @@ Getting started
 <dependency>
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
-    <version>2.9.2</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
     <packaging>bundle</packaging>
-    <version>2.9.4-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>Spark</name>
-    <description>A micro framework for creating web applications in Kotlin and Java 8 with minimal effort</description>
+    <description>A micro framework for creating web applications in Kotlin and Java 11 with minimal effort</description>
     <url>http://www.sparkjava.com</url>
     <licenses>
         <license>
@@ -31,8 +31,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cvss.core>4</cvss.core>
-        <java.version>1.8</java.version>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <java.version>11</java.version>
+        <jetty.version>11.0.9</jetty.version>
         <slf4j.version>1.7.36</slf4j.version>
         <!-- Test -->
         <junit.version>5.8.2</junit.version>
@@ -42,13 +42,14 @@
         <httpclient.version>4.5.13</httpclient.version>
         <freemarker.version>2.3.31</freemarker.version>
         <gson.version>2.9.0</gson.version>
+        <classgraph.version>4.8.143</classgraph.version>
         <!-- Plugin -->
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
         <maven-bundle-plugin.version>5.1.4</maven-bundle-plugin.version>
-        <dependency-check-maven.version>7.0.1</dependency-check-maven.version>
+        <dependency-check-maven.version>7.0.4</dependency-check-maven.version>
     </properties>
 
     <dependencies>
@@ -58,30 +59,26 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
-
         <!-- JETTY DEPENDENCIES -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>${jetty.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
             <version>${jetty.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
+            <artifactId>websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
@@ -89,7 +86,6 @@
             <artifactId>websocket-servlet</artifactId>
             <version>${jetty.version}</version>
         </dependency>
-
         <!-- JUNIT DEPENDENCY FOR TESTING -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -141,14 +137,18 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-client</artifactId>
+            <artifactId>websocket-jetty-client</artifactId>
             <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
+		<dependency>
+		    <groupId>io.github.classgraph</groupId>
+		    <artifactId>classgraph</artifactId>
+		    <version>${classgraph.version}</version>
+            <scope>test</scope>
+		</dependency>
     </dependencies>
-
     <build>
-
         <resources>
             <resource>
                 <filtering>false</filtering>
@@ -165,7 +165,6 @@
                 </excludes>
             </resource>
         </resources>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/spark/HaltException.java
+++ b/src/main/java/spark/HaltException.java
@@ -16,7 +16,7 @@
  */
 package spark;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Exception used for stopping the execution

--- a/src/main/java/spark/QueryParamsMap.java
+++ b/src/main/java/spark/QueryParamsMap.java
@@ -6,7 +6,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * These objects represent the parameters sent on a Http Request. <br>

--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -28,9 +28,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 import spark.routematch.RouteMatch;
 import spark.utils.IOUtils;

--- a/src/main/java/spark/RequestResponseFactory.java
+++ b/src/main/java/spark/RequestResponseFactory.java
@@ -16,8 +16,8 @@
  */
 package spark;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import spark.routematch.RouteMatch;
 

--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -19,8 +19,8 @@ package spark;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Date;

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -682,7 +682,7 @@ public final class Service extends Routable {
      */
     public synchronized <T extends Exception> void exception(Class<T> exceptionClass, ExceptionHandler<? super T> handler) {
         // wrap
-        ExceptionHandlerImpl<T> wrapper = new ExceptionHandlerImpl<T>(exceptionClass) {
+        ExceptionHandlerImpl<T> wrapper = new ExceptionHandlerImpl<>(exceptionClass) {
             @Override
             public void handle(T exception, Request request, Response response) {
                 handler.handle(exception, request, response);

--- a/src/main/java/spark/Session.java
+++ b/src/main/java/spark/Session.java
@@ -4,7 +4,7 @@ import java.util.Enumeration;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 
 import spark.utils.Assert;
 

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -18,8 +18,6 @@ package spark.embeddedserver.jetty;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -131,15 +129,15 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         if (webSocketServletContextHandler == null) {
             server.setHandler(handler);
         } else {
-            List<Handler> handlersInList = new ArrayList<>();
-            handlersInList.add(handler);
+            final Handler[] handlers = new Handler[2];
+            handlers[0] = handler;
 
             // WebSocket handler must be the last one
-            handlersInList.add(webSocketServletContextHandler);
+            handlers[1] = webSocketServletContextHandler;
 
-            HandlerList handlers = new HandlerList();
-            handlers.setHandlers(handlersInList.toArray(new Handler[0]));
-            server.setHandler(handlers);
+            final HandlerList handlerList = new HandlerList();
+            handlerList.setHandlers(handlers);
+            server.setHandler(handlerList);
         }
 
         logger.info("== {} has ignited ...", NAME);

--- a/src/main/java/spark/embeddedserver/jetty/HttpRequestWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/HttpRequestWrapper.java
@@ -19,10 +19,10 @@ package spark.embeddedserver.jetty;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 
 import spark.utils.IOUtils;
 

--- a/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
+++ b/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
@@ -18,10 +18,10 @@ package spark.embeddedserver.jetty;
 
 import java.io.IOException;
 
-import javax.servlet.Filter;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.session.SessionHandler;
@@ -40,12 +40,8 @@ public class JettyHandler extends SessionHandler {
     }
 
     @Override
-    public void doHandle(
-            String target,
-            Request baseRequest,
-            HttpServletRequest request,
-            HttpServletResponse response) throws IOException, ServletException {
-
+    public void doHandle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
         HttpRequestWrapper wrapper = new HttpRequestWrapper(request);
         filter.doFilter(wrapper, response, null);
 
@@ -54,7 +50,5 @@ public class JettyHandler extends SessionHandler {
         } else {
             baseRequest.setHandled(true);
         }
-
     }
-
 }

--- a/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactory.java
@@ -15,14 +15,14 @@
  */
 package spark.embeddedserver.jetty.websocket;
 
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Factory class to create {@link WebSocketCreator} implementations that
+ * Factory class to create {@link JettyWebSocketCreator} implementations that
  * delegate to the given handler class.
  *
  * @author Ignasi Barrera
@@ -30,18 +30,18 @@ import static java.util.Objects.requireNonNull;
 public class WebSocketCreatorFactory {
 
     /**
-     * Creates a {@link WebSocketCreator} that uses the given handler class/instance for
+     * Creates a {@link JettyWebSocketCreator} that uses the given handler class/instance for
      * the WebSocket connections.
      *
      * @param handlerWrapper The wrapped handler to use to manage WebSocket connections.
      * @return The WebSocketCreator.
      */
-    public static WebSocketCreator create(WebSocketHandlerWrapper handlerWrapper) {
+    public static JettyWebSocketCreator create(WebSocketHandlerWrapper handlerWrapper) {
         return new SparkWebSocketCreator(handlerWrapper.getHandler());
     }
 
     // Package protected to be visible to the unit tests
-    static class SparkWebSocketCreator implements WebSocketCreator {
+    static class SparkWebSocketCreator implements JettyWebSocketCreator {
         private final Object handler;
 
         private SparkWebSocketCreator(Object handler) {
@@ -49,8 +49,7 @@ public class WebSocketCreatorFactory {
         }
 
         @Override
-        public Object createWebSocket(ServletUpgradeRequest request,
-                                      ServletUpgradeResponse response) {
+        public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp) {
             return handler;
         }
 

--- a/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketHandlerClassWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketHandlerClassWrapper.java
@@ -2,6 +2,8 @@ package spark.embeddedserver.jetty.websocket;
 
 import static java.util.Objects.requireNonNull;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class WebSocketHandlerClassWrapper implements WebSocketHandlerWrapper {
     
     private final Class<?> handlerClass;
@@ -11,13 +13,13 @@ public class WebSocketHandlerClassWrapper implements WebSocketHandlerWrapper {
         WebSocketHandlerWrapper.validateHandlerClass(handlerClass);
         this.handlerClass = handlerClass;
     }
+    
     @Override
     public Object getHandler() {
         try {
-            return handlerClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException ex) {
+            return handlerClass.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException ex) {
             throw new RuntimeException("Could not instantiate websocket handler", ex);
         }
     }
-
 }

--- a/src/main/java/spark/http/matching/Body.java
+++ b/src/main/java/spark/http/matching/Body.java
@@ -19,8 +19,8 @@ package spark.http.matching;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import spark.utils.GzipUtils;
 import spark.serialization.SerializerChain;

--- a/src/main/java/spark/http/matching/GeneralError.java
+++ b/src/main/java/spark/http/matching/GeneralError.java
@@ -16,8 +16,8 @@
  */
 package spark.http.matching;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import spark.CustomErrorPages;
 import spark.ExceptionHandlerImpl;

--- a/src/main/java/spark/http/matching/Halt.java
+++ b/src/main/java/spark/http/matching/Halt.java
@@ -16,7 +16,7 @@
  */
 package spark.http.matching;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import spark.HaltException;
 

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -18,14 +18,14 @@ package spark.http.matching;
 
 import java.io.IOException;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import spark.CustomErrorPages;
 import spark.ExceptionMapper;

--- a/src/main/java/spark/http/matching/RequestWrapper.java
+++ b/src/main/java/spark/http/matching/RequestWrapper.java
@@ -19,7 +19,7 @@ package spark.http.matching;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import spark.Access;
 import spark.QueryParamsMap;

--- a/src/main/java/spark/http/matching/ResponseWrapper.java
+++ b/src/main/java/spark/http/matching/ResponseWrapper.java
@@ -16,7 +16,7 @@
  */
 package spark.http.matching;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import spark.Response;
 

--- a/src/main/java/spark/http/matching/RouteContext.java
+++ b/src/main/java/spark/http/matching/RouteContext.java
@@ -16,7 +16,7 @@
  */
 package spark.http.matching;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import spark.Response;
 import spark.route.*;

--- a/src/main/java/spark/resource/AbstractResourceHandler.java
+++ b/src/main/java/spark/resource/AbstractResourceHandler.java
@@ -19,8 +19,8 @@ package spark.resource;
 
 import java.net.MalformedURLException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Abstract class providing functionality for finding resources based on a Http Servlet request.

--- a/src/main/java/spark/servlet/FilterTools.java
+++ b/src/main/java/spark/servlet/FilterTools.java
@@ -16,8 +16,8 @@
  */
 package spark.servlet;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 

--- a/src/main/java/spark/servlet/SparkFilter.java
+++ b/src/main/java/spark/servlet/SparkFilter.java
@@ -18,15 +18,15 @@ package spark.servlet;
 
 import java.io.IOException;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
+++ b/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
@@ -25,8 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/spark/utils/GzipUtils.java
+++ b/src/main/java/spark/utils/GzipUtils.java
@@ -22,8 +22,8 @@ import java.util.Collections;
 import java.util.function.Predicate;
 import java.util.zip.GZIPOutputStream;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * GZIP utility class.

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -182,7 +182,7 @@ public class GenericIntegrationTest {
         });
 
         get("/exception", (request, response) -> {
-            throw new RuntimeException();
+            throw new RuntimeException("Expected test error");
         });
 
         afterAfter("/exception", (request, response) -> response.body("done executed for exception"));

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -3,9 +3,9 @@ package spark;
 import spark.routematch.RouteMatch;
 import spark.util.SparkTestUtil;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/spark/ResponseTest.java
+++ b/src/test/java/spark/ResponseTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.powermock.reflect.Whitebox;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/spark/ResponseWrapperDelegationTest.java
+++ b/src/test/java/spark/ResponseWrapperDelegationTest.java
@@ -64,6 +64,6 @@ public class ResponseWrapperDelegationTest {
         UrlResponse response = testUtil.get("/json");
         assertEquals(200, response.status);
         assertEquals("{\"status\": \"ok\"}", response.body);
-        assertEquals("text/plain", response.headers.get("Content-Type"));
+        assertEquals("text/plain;charset=utf-8", response.headers.get("Content-Type"));
     }
 }

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -1,6 +1,6 @@
 package spark;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/spark/SessionTest.java
+++ b/src/test/java/spark/SessionTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/test/java/spark/customerrorpages/CustomErrorPagesTest.java
+++ b/src/test/java/spark/customerrorpages/CustomErrorPagesTest.java
@@ -35,7 +35,7 @@ public class CustomErrorPagesTest {
         get("/hello", (q, a) -> HELLO_WORLD);
 
         get("/raiseinternal", (q, a) -> {
-            throw new Exception("");
+            throw new Exception("Expected test error");
         });
 
         notFound(CUSTOM_NOT_FOUND);

--- a/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactoryTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
 import org.junit.jupiter.api.Test;
 import spark.embeddedserver.jetty.websocket.WebSocketCreatorFactory.SparkWebSocketCreator;
 
@@ -14,12 +14,12 @@ public class WebSocketCreatorFactoryTest {
 
     @Test
     public void testCreateWebSocketHandler() {
-        WebSocketCreator annotated =
+        JettyWebSocketCreator annotated =
                 WebSocketCreatorFactory.create(new WebSocketHandlerClassWrapper(AnnotatedHandler.class));
         assertTrue(annotated instanceof SparkWebSocketCreator);
         assertTrue(((SparkWebSocketCreator) annotated).getHandler() instanceof AnnotatedHandler);
 
-        WebSocketCreator listener =
+        JettyWebSocketCreator listener =
                 WebSocketCreatorFactory.create(new WebSocketHandlerClassWrapper(ListenerHandler.class));
         assertTrue(listener instanceof SparkWebSocketCreator);
         assertTrue(((SparkWebSocketCreator) listener).getHandler() instanceof ListenerHandler);

--- a/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketServletContextHandlerFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/websocket/WebSocketServletContextHandlerFactoryTest.java
@@ -5,125 +5,83 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mockConstructionWithAnswer;
 
-import java.util.HashMap;
+import jakarta.servlet.Filter;
 import java.util.Map;
 import java.util.Optional;
-import javax.servlet.ServletContext;
-import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.PathSpec;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler.Context;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.websocket.server.NativeWebSocketConfiguration;
-import org.eclipse.jetty.websocket.server.WebSocketServerFactory;
-import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
+import org.eclipse.jetty.websocket.core.server.WebSocketNegotiator;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.stubbing.Answer;
 
 public class WebSocketServletContextHandlerFactoryTest {
 
-    final String webSocketPath = "/websocket";
-    private ServletContextHandler servletContextHandler;
+    private static final String WEB_SOCKET_PATH = "/websocket";
 
     @Test
     public void testCreate_whenWebSocketHandlersIsNull_thenReturnNull() {
-
-        servletContextHandler = WebSocketServletContextHandlerFactory.create(null, Optional.empty());
+        final ServletContextHandler servletContextHandler = WebSocketServletContextHandlerFactory.create(null, Optional.empty());
 
         assertNull(servletContextHandler, "Should return null because no WebSocket Handlers were passed");
-
     }
 
     @Test
-    public void testCreate_whenNoIdleTimeoutIsPresent() {
-
-        Map<String, WebSocketHandlerWrapper> webSocketHandlers = new HashMap<>();
-
-        webSocketHandlers.put(webSocketPath, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
-
-        servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.empty());
-
-        ServletContext servletContext = servletContextHandler.getServletContext();
-
-        WebSocketUpgradeFilter webSocketUpgradeFilter = (WebSocketUpgradeFilter) servletContext
-                .getAttribute("org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter");
-
+    public void testCreate_whenNoIdleTimeoutIsPresent() throws Exception {
+        final Map<String, WebSocketHandlerWrapper> webSocketHandlers = Map.of(WEB_SOCKET_PATH, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
+        final ServletContextHandler servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.empty());
+   
+        final Server server = new Server();
+        server.setHandler(servletContextHandler);
+        server.start();
+        
+        final Context servletContext = servletContextHandler.getServletContext();
+        final Filter webSocketUpgradeFilter = WebSocketUpgradeFilter.getFilter(servletContext).getFilter();
         assertNotNull(webSocketUpgradeFilter, "Should return a WebSocketUpgradeFilter because we configured it to have one");
 
-        NativeWebSocketConfiguration webSocketConfiguration = (NativeWebSocketConfiguration) servletContext
-                .getAttribute(NativeWebSocketConfiguration.class.getName());
-
-        MappedResource<WebSocketCreator> mappedResource = webSocketConfiguration.getMatch("/websocket");
-        PathSpec pathSpec = mappedResource.getPathSpec();
-
-        assertEquals(webSocketPath, pathSpec.getDeclaration(),
-                "Should return the WebSocket path specified when context handler was created");
-
-        // Because spark works on a non-initialized / non-started ServletContextHandler
-        // and WebSocketUpgradeFilter
-        // the stored WebSocketCreator is wrapped for persistence through the start/stop
-        // of those contexts.
-        // You cannot unwrap or cast to that WebSocketTestHandler this way.
-        // Only websockets that are added during a live context can be cast this way.
-        // WebSocketCreator sc = mappedResource.getResource();
-        // assertTrue("Should return true because handler should be an instance of the
-        // one we passed when it was created",
-        // sc.getHandler() instanceof WebSocketTestHandler);
+        final WebSocketMappings webSocketMappings = WebSocketMappings.getMappings(servletContext);
+        final WebSocketNegotiator negotiator = webSocketMappings.getMatchedNegotiator(WEB_SOCKET_PATH, (PathSpec p) -> {});
+        assertNotNull(negotiator, "Should return the WebSocketNegotiator path specified when context handler was created");
     }
-
+    
     @Test
-    public void testCreate_whenTimeoutIsPresent() {
-
+    public void testCreate_whenTimeoutIsPresent() throws Exception {
         final Long timeout = 1000L;
+        final Map<String, WebSocketHandlerWrapper> webSocketHandlers = Map.of(WEB_SOCKET_PATH, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
 
-        Map<String, WebSocketHandlerWrapper> webSocketHandlers = new HashMap<>();
+        final ServletContextHandler servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.of(timeout));
 
-        webSocketHandlers.put(webSocketPath, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
-
-        servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.of(timeout));
-
-        ServletContext servletContext = servletContextHandler.getServletContext();
-
-        WebSocketUpgradeFilter webSocketUpgradeFilter = (WebSocketUpgradeFilter) servletContext
-                .getAttribute("org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter");
-
+        final Server server = new Server();
+        server.setHandler(servletContextHandler);
+        server.start();
+        
+        final Context servletContext = servletContextHandler.getServletContext();
+        final Filter webSocketUpgradeFilter = WebSocketUpgradeFilter.getFilter(servletContext).getFilter();
         assertNotNull(webSocketUpgradeFilter, "Should return a WebSocketUpgradeFilter because we configured it to have one");
 
-        NativeWebSocketConfiguration webSocketConfiguration = (NativeWebSocketConfiguration) servletContext
-                .getAttribute(NativeWebSocketConfiguration.class.getName());
+        final JettyWebSocketServerContainer container = servletContextHandler.getBean(JettyWebSocketServerContainer.class);
 
-        WebSocketServerFactory webSocketServerFactory = webSocketConfiguration.getFactory();
-        assertEquals(timeout.longValue(), webSocketServerFactory.getPolicy().getIdleTimeout(),
+        assertEquals(timeout, container.getIdleTimeout().toMillis(),
                 "Timeout value should be the same as the timeout specified when context handler was created");
 
-        MappedResource<WebSocketCreator> mappedResource = webSocketConfiguration.getMatch("/websocket");
-        PathSpec pathSpec = mappedResource.getPathSpec();
-
-        assertEquals(webSocketPath, pathSpec.getDeclaration(),
-                "Should return the WebSocket path specified when context handler was created");
-
-        // Because spark works on a non-initialized / non-started ServletContextHandler
-        // and WebSocketUpgradeFilter
-        // the stored WebSocketCreator is wrapped for persistence through the start/stop
-        // of those contexts.
-        // You cannot unwrap or cast to that WebSocketTestHandler this way.
-        // Only websockets that are added during a live context can be cast this way.
-        // WebSocketCreator sc = mappedResource.getResource();
-        // assertTrue(sc.getHandler() instanceof WebSocketTestHandler,
-        // "Should return true because handler should be an instance of the one we
-        // passed when it was created",);
+        final WebSocketMappings webSocketMappings = WebSocketMappings.getMappings(servletContext);
+        final WebSocketNegotiator negotiator = webSocketMappings.getMatchedNegotiator(WEB_SOCKET_PATH, (PathSpec p) -> {});
+        assertNotNull(negotiator, "Should return the WebSocketNegotiator path specified when context handler was created");
     }
 
     @Test
     public void testCreate_whenWebSocketContextHandlerCreationFails_thenThrowException() {
         try (MockedConstruction<ServletContextHandler> ignored = mockConstructionWithAnswer(ServletContextHandler.class, (Answer<RuntimeException>) invocation -> {
-            throw new RuntimeException("Some problem initializing context handler!");
+            throw new RuntimeException("Expected test error");
         })) {
-            Map<String, WebSocketHandlerWrapper> webSocketHandlers = new HashMap<>();
+            final Map<String, WebSocketHandlerWrapper> webSocketHandlers = Map.of(WEB_SOCKET_PATH, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
 
-            webSocketHandlers.put(webSocketPath, new WebSocketHandlerClassWrapper(WebSocketTestHandler.class));
-
-            servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.empty());
+            final ServletContextHandler servletContextHandler = WebSocketServletContextHandlerFactory.create(webSocketHandlers, Optional.empty());
 
             assertNull(servletContextHandler, "Should return null because Websocket context handler was not created");
         }

--- a/src/test/java/spark/servlet/FilterConfigWrapper.java
+++ b/src/test/java/spark/servlet/FilterConfigWrapper.java
@@ -2,8 +2,8 @@ package spark.servlet;
 
 import java.util.Enumeration;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
 
 public class FilterConfigWrapper implements FilterConfig {
  


### PR DESCRIPTION
## Updating Spark to Java 11 and Jetty 11

Breaking changes by using Jakarta.

Added classgraph library as test dependency due to changes in
classloader in Java 9 and again in Java 11 to keep
StaticFilesFromArchiveTest test "as is".

Refactored WevSocket servlet context handler creation and it's tests.